### PR TITLE
Specify project encoding explicit to UTF-8 for all projects

### DIFF
--- a/bundles/tools.vitruv.change.atomic/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/tools.vitruv.change.atomic/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/bundles/tools.vitruv.change.composite/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/tools.vitruv.change.composite/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/bundles/tools.vitruv.change.correspondence/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/tools.vitruv.change.correspondence/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/bundles/tools.vitruv.change.interaction.model/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/tools.vitruv.change.interaction.model/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/bundles/tools.vitruv.change.interaction/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/tools.vitruv.change.interaction/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/bundles/tools.vitruv.change.propagation/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/tools.vitruv.change.propagation/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/bundles/tools.vitruv.testutils.metamodels/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/tools.vitruv.testutils.metamodels/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/bundles/tools.vitruv.testutils/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/tools.vitruv.testutils/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/features/tools.vitruv.change.feature/.settings/org.eclipse.core.resources.prefs
+++ b/features/tools.vitruv.change.feature/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/features/tools.vitruv.testutils.feature/.settings/org.eclipse.core.resources.prefs
+++ b/features/tools.vitruv.testutils.feature/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/releng/tools.vitruv.change.updatesite/.settings/org.eclipse.core.resources.prefs
+++ b/releng/tools.vitruv.change.updatesite/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/releng/tools.vitruv.change.workflow/.settings/org.eclipse.core.resources.prefs
+++ b/releng/tools.vitruv.change.workflow/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/tests/tools.vitruv.change.atomic.tests/.settings/org.eclipse.core.resources.prefs
+++ b/tests/tools.vitruv.change.atomic.tests/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/tests/tools.vitruv.change.composite.tests/.settings/org.eclipse.core.resources.prefs
+++ b/tests/tools.vitruv.change.composite.tests/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/tests/tools.vitruv.testutils.tests/.settings/org.eclipse.core.resources.prefs
+++ b/tests/tools.vitruv.testutils.tests/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8


### PR DESCRIPTION
As of Eclipse 06/22 a warning is generated if no explicit project encoding is specified ([source](https://www.eclipse.org/eclipse/news/4.24/platform.php#no-explicit-encoding-project-warning)).
This PR sets the default encoding for all projects to UTF-8.