### PR TITLE
`Proposal` Deploy release versions after creating a GitHub release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,8 @@ name: CI
 on:
   push:
     branches: [main]
-  create:
-    tags:
+  release:
+    types: [created]
   pull_request:
   schedule:
     - cron: '0 2 30 * *' # run nightly at 2:30 am
@@ -50,13 +50,13 @@ jobs:
           user_name: 'github-actions[bot]'
           user_email: 'github-actions[bot]@users.noreply.github.com'
       - name: Determine Release Version
-        if: startsWith(github.ref, 'refs/tags/releases/') && github.repository_owner == 'vitruv-tools'
+        if: github.event_name == 'release' && github.repository_owner == 'vitruv-tools'
         id: releaseVersion
-        uses: little-core-labs/get-git-tag@v3.0.2
-        with:
-           tagRegex: "releases/(.*)"
+        run: |
+          releaseVersion=$(echo ${{ github.event.release.tag_name }} | sed 's/^Releases\///') #trimm "Releases/" prefix from tag name
+          echo "::set-output name=tag::$releaseVersion"
       - name: Publish Release Update Site
-        if: startsWith(github.ref, 'refs/tags/releases/') && github.repository_owner == 'vitruv-tools'
+        if: github.event_name == 'release' && github.repository_owner == 'vitruv-tools'
         uses: peaceiris/actions-gh-pages@v3
         with:
           deploy_key: ${{ secrets.UPDATE_SITE_DEPLOY_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
         if: github.event_name == 'release' && github.repository_owner == 'vitruv-tools'
         id: releaseVersion
         run: |
-          releaseVersion=$(echo ${{ github.event.release.tag_name }} | sed 's/^Releases\///') #trimm "Releases/" prefix from tag name
+          releaseVersion=$(echo ${{ github.event.release.tag_name }} | sed 's/^releases\///') #trimm "releases/" prefix from tag name
           echo "::set-output name=tag::$releaseVersion"
       - name: Publish Release Update Site
         if: github.event_name == 'release' && github.repository_owner == 'vitruv-tools'


### PR DESCRIPTION
Similar to [Maven-Build-Parent#26](https://github.com/vitruv-tools/Maven-Build-Parent/pull/26), this PR adapts the release process to create a release after a GitHub release is created instead of depending on tags.

If this proposal is accepted, the actions for Vitruv-DSLs, Vitruv, and Vitruv-Applications-CBS will be migrated to also use GitHub releases.