### PR TITLE
Preparation for renaming all Vitruv default branches to `main`

### DIFF
--- a/.github/workflows/applicationsvalidation.yml
+++ b/.github/workflows/applicationsvalidation.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           path: framework
           repository: vitruv-tools/Vitruv
-          ref: master
+          ref: main
           fetch-depth: 0
       - name: Checkout DSLs
         uses: actions/checkout@v3
@@ -30,7 +30,7 @@ jobs:
         with:
           path: cbsapplications
           repository: vitruv-tools/Vitruv-Applications-ComponentBasedSystems
-          ref: master
+          ref: main
           fetch-depth: 0
       - name: Checkout Matching Domains/Applications Branches
         run: |

--- a/.github/workflows/applicationsvalidation.yml
+++ b/.github/workflows/applicationsvalidation.yml
@@ -32,7 +32,7 @@ jobs:
           repository: vitruv-tools/Vitruv-Applications-ComponentBasedSystems
           ref: main
           fetch-depth: 0
-      - name: Checkout Matching Domains/Applications Branches
+      - name: Checkout Matching Framework/DSLs/Applications Branches
         run: |
           cd framework
           git checkout -B ${{ github.head_ref }} origin/${{ github.head_ref }} || true


### PR DESCRIPTION
Adapts the GitHub actions to renaming the Vitruv repository's default branch to `main`.
Adapts the GitHub actions to renaming the Application-CBS repository's default branch to `main`.

⚠️ Depends on [Vitruv#545](https://github.com/vitruv-tools/Vitruv/pull/545)
⚠️ Depends on [Vitruv-Applications-CBS#211](https://github.com/vitruv-tools/Vitruv-Applications-ComponentBasedSystems/pull/211)