### PR TITLE
`Proposal` Refactor GitHub actions to explicitly define dependencies

### DIFF
--- a/.github/workflows/applicationsvalidation.yml
+++ b/.github/workflows/applicationsvalidation.yml
@@ -41,77 +41,60 @@ jobs:
           name: change
           path: change/releng/tools.vitruv.change.updatesite/target/repository
           retention-days: 1
-validate_applications:
-  needs: build_change
-  runs-on: ubuntu-latest
-  steps:
-    - name: Download Change Artifact
-      uses: actions/download-artifact@v3
-      with:
-        name: change
-        path: change
-    - name: Checkout Framework
-      uses: actions/checkout@v3
-      with:
-        path: framework
-        repository: vitruv-tools/Vitruv
-        ref: main
-        fetch-depth: 0
-    - name: Checkout DSLs
-      uses: actions/checkout@v3
-      with:
-        path: dsls
-        repository: vitruv-tools/Vitruv-DSLs
-        ref: main
-        fetch-depth: 0
-    - name: Checkout CBS Applications
-      uses: actions/checkout@v3
-      with:
-        path: cbsapplications
-        repository: vitruv-tools/Vitruv-Applications-ComponentBasedSystems
-        ref: main
-        fetch-depth: 0
-    - name: Checkout Matching Framework/DSLs/Applications Branches
-      run: |
-        cd framework
-        git checkout -B ${{ github.head_ref }} origin/${{ github.head_ref }} || true
-        cd ../dsls
-        git checkout -B ${{ github.head_ref }} origin/${{ github.head_ref }} || true
-        cd ../cbsapplications
-        git checkout -B ${{ github.head_ref }} origin/${{ github.head_ref }} || true
-    - name: Cache
-      uses: actions/cache@v3
-      with:
-        path: ~/.m2
-        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml', '**/MANIFEST.MF') }}
-        restore-keys: ${{ runner.os }}-m2
-    - name: Set up JDK
-      uses: actions/setup-java@v2
-      with:
-        distribution: 'zulu'
-        java-version: 11
-    - name: Build Framework
-      working-directory: ./framework
-      run: >
-        ./mvnw -B -U clean verify
-        -Dvitruv.change.url="file:///\${GITHUB_WORKSPACE}/change"
-        -Dstyle.color=always
-        -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
-        -Dorg.slf4j.simpleLogger.log.org.eclipse.tycho.core.resolver.DefaultTychoResolver=warn
-        -Dorg.slf4j.simpleLogger.log.org.eclipse.tycho.osgi.configuration.MavenContextConfigurator=warn
-        -Dorg.slf4j.simpleLogger.log.org.eclipse.sisu.equinox.launching.internal.DefaultEquinoxLauncher=warn
-        -Dorg.slf4j.simpleLogger.log.org.eclipse.xtext.maven.XtextGenerateMojo=warn
-        -Dorg.apache.commons.logging.Log=org.apache.commons.logging.impl.NoOpLog
-      env: 
-        MAVEN_OPTS: -Djansi.force=true
-    - name: Build DSLs
-      uses: GabrielBB/xvfb-action@v1
-      with:
-        working-directory: ./dsls
+  validate_applications:
+    needs: build_change
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download Change Artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: change
+          path: change
+      - name: Checkout Framework
+        uses: actions/checkout@v3
+        with:
+          path: framework
+          repository: vitruv-tools/Vitruv
+          ref: main
+          fetch-depth: 0
+      - name: Checkout DSLs
+        uses: actions/checkout@v3
+        with:
+          path: dsls
+          repository: vitruv-tools/Vitruv-DSLs
+          ref: main
+          fetch-depth: 0
+      - name: Checkout CBS Applications
+        uses: actions/checkout@v3
+        with:
+          path: cbsapplications
+          repository: vitruv-tools/Vitruv-Applications-ComponentBasedSystems
+          ref: main
+          fetch-depth: 0
+      - name: Checkout Matching Framework/DSLs/Applications Branches
+        run: |
+          cd framework
+          git checkout -B ${{ github.head_ref }} origin/${{ github.head_ref }} || true
+          cd ../dsls
+          git checkout -B ${{ github.head_ref }} origin/${{ github.head_ref }} || true
+          cd ../cbsapplications
+          git checkout -B ${{ github.head_ref }} origin/${{ github.head_ref }} || true
+      - name: Cache
+        uses: actions/cache@v3
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml', '**/MANIFEST.MF') }}
+          restore-keys: ${{ runner.os }}-m2
+      - name: Set up JDK
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'zulu'
+          java-version: 11
+      - name: Build Framework
+        working-directory: ./framework
         run: >
           ./mvnw -B -U clean verify
-          -Dvitruv.change.url=file:///${GITHUB_WORKSPACE}/change
-          -Dvitruv.framework.path=${GITHUB_WORKSPACE}/framework
+          -Dvitruv.change.url="file:///\${GITHUB_WORKSPACE}/change"
           -Dstyle.color=always
           -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
           -Dorg.slf4j.simpleLogger.log.org.eclipse.tycho.core.resolver.DefaultTychoResolver=warn
@@ -119,23 +102,40 @@ validate_applications:
           -Dorg.slf4j.simpleLogger.log.org.eclipse.sisu.equinox.launching.internal.DefaultEquinoxLauncher=warn
           -Dorg.slf4j.simpleLogger.log.org.eclipse.xtext.maven.XtextGenerateMojo=warn
           -Dorg.apache.commons.logging.Log=org.apache.commons.logging.impl.NoOpLog
-      env: 
-        MAVEN_OPTS: -Djansi.force=true
-    - name: Build Applications
-      uses: GabrielBB/xvfb-action@v1
-      with:
-        working-directory: ./cbsapplications
-        run: >
-          ./mvnw -B -U clean verify
-          -Dvitruv.change.url=file:///${GITHUB_WORKSPACE}/change
-          -Dvitruv.framework.path=${GITHUB_WORKSPACE}/framework
-          -Dvitruv.dsls.path=${GITHUB_WORKSPACE}/dsls
-          -Dstyle.color=always
-          -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
-          -Dorg.slf4j.simpleLogger.log.org.eclipse.tycho.core.resolver.DefaultTychoResolver=warn
-          -Dorg.slf4j.simpleLogger.log.org.eclipse.tycho.osgi.configuration.MavenContextConfigurator=warn
-          -Dorg.slf4j.simpleLogger.log.org.eclipse.sisu.equinox.launching.internal.DefaultEquinoxLauncher=warn
-          -Dorg.slf4j.simpleLogger.log.org.eclipse.xtext.maven.XtextGenerateMojo=warn
-          -Dorg.apache.commons.logging.Log=org.apache.commons.logging.impl.NoOpLog
-      env: 
-        MAVEN_OPTS: -Djansi.force=true
+        env: 
+          MAVEN_OPTS: -Djansi.force=true
+      - name: Build DSLs
+        uses: GabrielBB/xvfb-action@v1
+        with:
+          working-directory: ./dsls
+          run: >
+            ./mvnw -B -U clean verify
+            -Dvitruv.change.url=file:///${GITHUB_WORKSPACE}/change
+            -Dvitruv.framework.path=${GITHUB_WORKSPACE}/framework
+            -Dstyle.color=always
+            -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+            -Dorg.slf4j.simpleLogger.log.org.eclipse.tycho.core.resolver.DefaultTychoResolver=warn
+            -Dorg.slf4j.simpleLogger.log.org.eclipse.tycho.osgi.configuration.MavenContextConfigurator=warn
+            -Dorg.slf4j.simpleLogger.log.org.eclipse.sisu.equinox.launching.internal.DefaultEquinoxLauncher=warn
+            -Dorg.slf4j.simpleLogger.log.org.eclipse.xtext.maven.XtextGenerateMojo=warn
+            -Dorg.apache.commons.logging.Log=org.apache.commons.logging.impl.NoOpLog
+        env: 
+          MAVEN_OPTS: -Djansi.force=true
+      - name: Build Applications
+        uses: GabrielBB/xvfb-action@v1
+        with:
+          working-directory: ./cbsapplications
+          run: >
+            ./mvnw -B -U clean verify
+            -Dvitruv.change.url=file:///${GITHUB_WORKSPACE}/change
+            -Dvitruv.framework.path=${GITHUB_WORKSPACE}/framework
+            -Dvitruv.dsls.path=${GITHUB_WORKSPACE}/dsls
+            -Dstyle.color=always
+            -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+            -Dorg.slf4j.simpleLogger.log.org.eclipse.tycho.core.resolver.DefaultTychoResolver=warn
+            -Dorg.slf4j.simpleLogger.log.org.eclipse.tycho.osgi.configuration.MavenContextConfigurator=warn
+            -Dorg.slf4j.simpleLogger.log.org.eclipse.sisu.equinox.launching.internal.DefaultEquinoxLauncher=warn
+            -Dorg.slf4j.simpleLogger.log.org.eclipse.xtext.maven.XtextGenerateMojo=warn
+            -Dorg.apache.commons.logging.Log=org.apache.commons.logging.impl.NoOpLog
+        env: 
+          MAVEN_OPTS: -Djansi.force=true

--- a/.github/workflows/applicationsvalidation.yml
+++ b/.github/workflows/applicationsvalidation.yml
@@ -41,7 +41,8 @@ jobs:
           name: change
           path: change/releng/tools.vitruv.change.updatesite/target/repository
           retention-days: 1
-  validate_applications:
+          
+  validate_framework:
     needs: build_change
     runs-on: ubuntu-latest
     steps:
@@ -57,27 +58,9 @@ jobs:
           repository: vitruv-tools/Vitruv
           ref: main
           fetch-depth: 0
-      - name: Checkout DSLs
-        uses: actions/checkout@v3
-        with:
-          path: dsls
-          repository: vitruv-tools/Vitruv-DSLs
-          ref: main
-          fetch-depth: 0
-      - name: Checkout CBS Applications
-        uses: actions/checkout@v3
-        with:
-          path: cbsapplications
-          repository: vitruv-tools/Vitruv-Applications-ComponentBasedSystems
-          ref: main
-          fetch-depth: 0
-      - name: Checkout Matching Framework/DSLs/Applications Branches
+      - name: Checkout Matching Framework Branches
         run: |
           cd framework
-          git checkout -B ${{ github.head_ref }} origin/${{ github.head_ref }} || true
-          cd ../dsls
-          git checkout -B ${{ github.head_ref }} origin/${{ github.head_ref }} || true
-          cd ../cbsapplications
           git checkout -B ${{ github.head_ref }} origin/${{ github.head_ref }} || true
       - name: Cache
         uses: actions/cache@v3
@@ -104,6 +87,49 @@ jobs:
           -Dorg.apache.commons.logging.Log=org.apache.commons.logging.impl.NoOpLog
         env: 
           MAVEN_OPTS: -Djansi.force=true
+      - name: Store Framework Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: framework
+          path: framework/releng/tools.vitruv.updatesite/target/repository
+          retention-days: 1
+
+  validate_DSLs:
+    needs: [build_change, validate_framework]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download Change Artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: change
+          path: change
+      - name: Download Framework Artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: framework
+          path: framework
+      - name: Checkout DSLs
+        uses: actions/checkout@v3
+        with:
+          path: dsls
+          repository: vitruv-tools/Vitruv-DSLs
+          ref: main
+          fetch-depth: 0
+      - name: Checkout Matching DSLs Branches
+        run: |
+          cd dsls
+          git checkout -B ${{ github.head_ref }} origin/${{ github.head_ref }} || true
+      - name: Cache
+        uses: actions/cache@v3
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml', '**/MANIFEST.MF') }}
+          restore-keys: ${{ runner.os }}-m2
+      - name: Set up JDK
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'zulu'
+          java-version: 11
       - name: Build DSLs
         uses: GabrielBB/xvfb-action@v1
         with:
@@ -111,7 +137,7 @@ jobs:
           run: >
             ./mvnw -B -U clean verify
             -Dvitruv.change.url=file:///${GITHUB_WORKSPACE}/change
-            -Dvitruv.framework.path=${GITHUB_WORKSPACE}/framework
+            -Dvitruv.framework.url=file:///${GITHUB_WORKSPACE}/framework
             -Dstyle.color=always
             -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
             -Dorg.slf4j.simpleLogger.log.org.eclipse.tycho.core.resolver.DefaultTychoResolver=warn
@@ -121,6 +147,54 @@ jobs:
             -Dorg.apache.commons.logging.Log=org.apache.commons.logging.impl.NoOpLog
         env: 
           MAVEN_OPTS: -Djansi.force=true
+      - name: Store DSLs Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: dsls
+          path: dsls/releng/tools.vitruv.dsls.updatesite/target/repository
+          retention-days: 1
+
+  validate_cbs_applications:
+    needs: [build_change, validate_framework, validate_DSLs]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download Change Artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: change
+          path: change
+      - name: Download Framework Artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: framework
+          path: framework
+      - name: Download DSLs Artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: dsls
+          path: dsls
+      - name: Checkout CBS Applications
+        uses: actions/checkout@v3
+        with:
+          path: cbsapplications
+          repository: vitruv-tools/Vitruv-Applications-ComponentBasedSystems
+          ref: main
+          fetch-depth: 0
+      - name: Checkout Matching Applications Branches
+        run: |
+          cd cbsapplications
+          git checkout -B ${{ github.head_ref }} origin/${{ github.head_ref }} || true
+      - name: Cache
+        uses: actions/cache@v3
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml', '**/MANIFEST.MF') }}
+          restore-keys: ${{ runner.os }}-m2
+      - name: Set up JDK
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'zulu'
+          java-version: 11
       - name: Build Applications
         uses: GabrielBB/xvfb-action@v1
         with:
@@ -128,8 +202,8 @@ jobs:
           run: >
             ./mvnw -B -U clean verify
             -Dvitruv.change.url=file:///${GITHUB_WORKSPACE}/change
-            -Dvitruv.framework.path=${GITHUB_WORKSPACE}/framework
-            -Dvitruv.dsls.path=${GITHUB_WORKSPACE}/dsls
+            -Dvitruv.framework.url=file:///${GITHUB_WORKSPACE}/framework
+            -Dvitruv.dsls.url=file:///${GITHUB_WORKSPACE}/dsls
             -Dstyle.color=always
             -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
             -Dorg.slf4j.simpleLogger.log.org.eclipse.tycho.core.resolver.DefaultTychoResolver=warn

--- a/.github/workflows/applicationsvalidation.yml
+++ b/.github/workflows/applicationsvalidation.yml
@@ -44,57 +44,74 @@ jobs:
 validate_applications:
   needs: build_change
   runs-on: ubuntu-latest
-    steps:
-      - name: Download Change Artifact
-        uses: actions/download-artifact@v3
-        with:
-          name: change
-          path: change
-      - name: Checkout Framework
-        uses: actions/checkout@v3
-        with:
-          path: framework
-          repository: vitruv-tools/Vitruv
-          ref: main
-          fetch-depth: 0
-      - name: Checkout DSLs
-        uses: actions/checkout@v3
-        with:
-          path: dsls
-          repository: vitruv-tools/Vitruv-DSLs
-          ref: main
-          fetch-depth: 0
-      - name: Checkout CBS Applications
-        uses: actions/checkout@v3
-        with:
-          path: cbsapplications
-          repository: vitruv-tools/Vitruv-Applications-ComponentBasedSystems
-          ref: main
-          fetch-depth: 0
-      - name: Checkout Matching Framework/DSLs/Applications Branches
-        run: |
-          cd framework
-          git checkout -B ${{ github.head_ref }} origin/${{ github.head_ref }} || true
-          cd ../dsls
-          git checkout -B ${{ github.head_ref }} origin/${{ github.head_ref }} || true
-          cd ../cbsapplications
-          git checkout -B ${{ github.head_ref }} origin/${{ github.head_ref }} || true
-      - name: Cache
-        uses: actions/cache@v3
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml', '**/MANIFEST.MF') }}
-          restore-keys: ${{ runner.os }}-m2
-      - name: Set up JDK
-        uses: actions/setup-java@v2
-        with:
-          distribution: 'zulu'
-          java-version: 11
-      - name: Build Framework
-        working-directory: ./framework
+  steps:
+    - name: Download Change Artifact
+      uses: actions/download-artifact@v3
+      with:
+        name: change
+        path: change
+    - name: Checkout Framework
+      uses: actions/checkout@v3
+      with:
+        path: framework
+        repository: vitruv-tools/Vitruv
+        ref: main
+        fetch-depth: 0
+    - name: Checkout DSLs
+      uses: actions/checkout@v3
+      with:
+        path: dsls
+        repository: vitruv-tools/Vitruv-DSLs
+        ref: main
+        fetch-depth: 0
+    - name: Checkout CBS Applications
+      uses: actions/checkout@v3
+      with:
+        path: cbsapplications
+        repository: vitruv-tools/Vitruv-Applications-ComponentBasedSystems
+        ref: main
+        fetch-depth: 0
+    - name: Checkout Matching Framework/DSLs/Applications Branches
+      run: |
+        cd framework
+        git checkout -B ${{ github.head_ref }} origin/${{ github.head_ref }} || true
+        cd ../dsls
+        git checkout -B ${{ github.head_ref }} origin/${{ github.head_ref }} || true
+        cd ../cbsapplications
+        git checkout -B ${{ github.head_ref }} origin/${{ github.head_ref }} || true
+    - name: Cache
+      uses: actions/cache@v3
+      with:
+        path: ~/.m2
+        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml', '**/MANIFEST.MF') }}
+        restore-keys: ${{ runner.os }}-m2
+    - name: Set up JDK
+      uses: actions/setup-java@v2
+      with:
+        distribution: 'zulu'
+        java-version: 11
+    - name: Build Framework
+      working-directory: ./framework
+      run: >
+        ./mvnw -B -U clean verify
+        -Dvitruv.change.url="file:///\${GITHUB_WORKSPACE}/change"
+        -Dstyle.color=always
+        -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+        -Dorg.slf4j.simpleLogger.log.org.eclipse.tycho.core.resolver.DefaultTychoResolver=warn
+        -Dorg.slf4j.simpleLogger.log.org.eclipse.tycho.osgi.configuration.MavenContextConfigurator=warn
+        -Dorg.slf4j.simpleLogger.log.org.eclipse.sisu.equinox.launching.internal.DefaultEquinoxLauncher=warn
+        -Dorg.slf4j.simpleLogger.log.org.eclipse.xtext.maven.XtextGenerateMojo=warn
+        -Dorg.apache.commons.logging.Log=org.apache.commons.logging.impl.NoOpLog
+      env: 
+        MAVEN_OPTS: -Djansi.force=true
+    - name: Build DSLs
+      uses: GabrielBB/xvfb-action@v1
+      with:
+        working-directory: ./dsls
         run: >
           ./mvnw -B -U clean verify
-          -Dvitruv.change.url="file:///\${GITHUB_WORKSPACE}/change"
+          -Dvitruv.change.url=file:///${GITHUB_WORKSPACE}/change
+          -Dvitruv.framework.path=${GITHUB_WORKSPACE}/framework
           -Dstyle.color=always
           -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
           -Dorg.slf4j.simpleLogger.log.org.eclipse.tycho.core.resolver.DefaultTychoResolver=warn
@@ -102,40 +119,23 @@ validate_applications:
           -Dorg.slf4j.simpleLogger.log.org.eclipse.sisu.equinox.launching.internal.DefaultEquinoxLauncher=warn
           -Dorg.slf4j.simpleLogger.log.org.eclipse.xtext.maven.XtextGenerateMojo=warn
           -Dorg.apache.commons.logging.Log=org.apache.commons.logging.impl.NoOpLog
-        env: 
-          MAVEN_OPTS: -Djansi.force=true
-      - name: Build DSLs
-        uses: GabrielBB/xvfb-action@v1
-        with:
-          working-directory: ./dsls
-          run: >
-            ./mvnw -B -U clean verify
-            -Dvitruv.change.url=file:///${GITHUB_WORKSPACE}/change
-            -Dvitruv.framework.path=${GITHUB_WORKSPACE}/framework
-            -Dstyle.color=always
-            -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
-            -Dorg.slf4j.simpleLogger.log.org.eclipse.tycho.core.resolver.DefaultTychoResolver=warn
-            -Dorg.slf4j.simpleLogger.log.org.eclipse.tycho.osgi.configuration.MavenContextConfigurator=warn
-            -Dorg.slf4j.simpleLogger.log.org.eclipse.sisu.equinox.launching.internal.DefaultEquinoxLauncher=warn
-            -Dorg.slf4j.simpleLogger.log.org.eclipse.xtext.maven.XtextGenerateMojo=warn
-            -Dorg.apache.commons.logging.Log=org.apache.commons.logging.impl.NoOpLog
-        env: 
-          MAVEN_OPTS: -Djansi.force=true
-      - name: Build Applications
-        uses: GabrielBB/xvfb-action@v1
-        with:
-          working-directory: ./cbsapplications
-          run: >
-            ./mvnw -B -U clean verify
-            -Dvitruv.change.url=file:///${GITHUB_WORKSPACE}/change
-            -Dvitruv.framework.path=${GITHUB_WORKSPACE}/framework
-            -Dvitruv.dsls.path=${GITHUB_WORKSPACE}/dsls
-            -Dstyle.color=always
-            -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
-            -Dorg.slf4j.simpleLogger.log.org.eclipse.tycho.core.resolver.DefaultTychoResolver=warn
-            -Dorg.slf4j.simpleLogger.log.org.eclipse.tycho.osgi.configuration.MavenContextConfigurator=warn
-            -Dorg.slf4j.simpleLogger.log.org.eclipse.sisu.equinox.launching.internal.DefaultEquinoxLauncher=warn
-            -Dorg.slf4j.simpleLogger.log.org.eclipse.xtext.maven.XtextGenerateMojo=warn
-            -Dorg.apache.commons.logging.Log=org.apache.commons.logging.impl.NoOpLog
-        env: 
-          MAVEN_OPTS: -Djansi.force=true
+      env: 
+        MAVEN_OPTS: -Djansi.force=true
+    - name: Build Applications
+      uses: GabrielBB/xvfb-action@v1
+      with:
+        working-directory: ./cbsapplications
+        run: >
+          ./mvnw -B -U clean verify
+          -Dvitruv.change.url=file:///${GITHUB_WORKSPACE}/change
+          -Dvitruv.framework.path=${GITHUB_WORKSPACE}/framework
+          -Dvitruv.dsls.path=${GITHUB_WORKSPACE}/dsls
+          -Dstyle.color=always
+          -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+          -Dorg.slf4j.simpleLogger.log.org.eclipse.tycho.core.resolver.DefaultTychoResolver=warn
+          -Dorg.slf4j.simpleLogger.log.org.eclipse.tycho.osgi.configuration.MavenContextConfigurator=warn
+          -Dorg.slf4j.simpleLogger.log.org.eclipse.sisu.equinox.launching.internal.DefaultEquinoxLauncher=warn
+          -Dorg.slf4j.simpleLogger.log.org.eclipse.xtext.maven.XtextGenerateMojo=warn
+          -Dorg.apache.commons.logging.Log=org.apache.commons.logging.impl.NoOpLog
+      env: 
+        MAVEN_OPTS: -Djansi.force=true

--- a/.github/workflows/applicationsvalidation.yml
+++ b/.github/workflows/applicationsvalidation.yml
@@ -4,12 +4,51 @@ on:
   pull_request:
 
 jobs:
-  validate:
+  build_change:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Change
         uses: actions/checkout@v3
         with:
+          path: change
+      - name: Cache
+        uses: actions/cache@v3
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml', '**/MANIFEST.MF') }}
+          restore-keys: ${{ runner.os }}-m2
+      - name: Set up JDK
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'zulu'
+          java-version: 11
+      - name: Build Change
+        working-directory: ./change
+        run: >
+          ./mvnw -B -U package -Dmaven.test.skip=true
+          -Dstyle.color=always
+          -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+          -Dorg.slf4j.simpleLogger.log.org.eclipse.tycho.core.resolver.DefaultTychoResolver=warn
+          -Dorg.slf4j.simpleLogger.log.org.eclipse.tycho.osgi.configuration.MavenContextConfigurator=warn
+          -Dorg.slf4j.simpleLogger.log.org.eclipse.sisu.equinox.launching.internal.DefaultEquinoxLauncher=warn
+          -Dorg.slf4j.simpleLogger.log.org.eclipse.xtext.maven.XtextGenerateMojo=warn
+          -Dorg.apache.commons.logging.Log=org.apache.commons.logging.impl.NoOpLog
+        env: 
+          MAVEN_OPTS: -Djansi.force=true
+      - name: Store Change Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: change
+          path: change/releng/tools.vitruv.change.updatesite/target/repository
+          retention-days: 1
+validate_applications:
+  needs: build_change
+  runs-on: ubuntu-latest
+    steps:
+      - name: Download Change Artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: change
           path: change
       - name: Checkout Framework
         uses: actions/checkout@v3
@@ -51,24 +90,11 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: 11
-      - name: Build Change
-        working-directory: ./change
-        run: >
-          ./mvnw -B -U package -Dmaven.test.skip=true
-          -Dstyle.color=always
-          -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
-          -Dorg.slf4j.simpleLogger.log.org.eclipse.tycho.core.resolver.DefaultTychoResolver=warn
-          -Dorg.slf4j.simpleLogger.log.org.eclipse.tycho.osgi.configuration.MavenContextConfigurator=warn
-          -Dorg.slf4j.simpleLogger.log.org.eclipse.sisu.equinox.launching.internal.DefaultEquinoxLauncher=warn
-          -Dorg.slf4j.simpleLogger.log.org.eclipse.xtext.maven.XtextGenerateMojo=warn
-          -Dorg.apache.commons.logging.Log=org.apache.commons.logging.impl.NoOpLog
-        env: 
-          MAVEN_OPTS: -Djansi.force=true
       - name: Build Framework
         working-directory: ./framework
         run: >
           ./mvnw -B -U clean verify
-          -Dvitruv.change.path="\${GITHUB_WORKSPACE}/change"
+          -Dvitruv.change.url="file:///\${GITHUB_WORKSPACE}/change"
           -Dstyle.color=always
           -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
           -Dorg.slf4j.simpleLogger.log.org.eclipse.tycho.core.resolver.DefaultTychoResolver=warn
@@ -84,7 +110,7 @@ jobs:
           working-directory: ./dsls
           run: >
             ./mvnw -B -U clean verify
-            -Dvitruv.change.path=${GITHUB_WORKSPACE}/change
+            -Dvitruv.change.url=file:///${GITHUB_WORKSPACE}/change
             -Dvitruv.framework.path=${GITHUB_WORKSPACE}/framework
             -Dstyle.color=always
             -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
@@ -101,7 +127,7 @@ jobs:
           working-directory: ./cbsapplications
           run: >
             ./mvnw -B -U clean verify
-            -Dvitruv.change.path=${GITHUB_WORKSPACE}/change
+            -Dvitruv.change.url=file:///${GITHUB_WORKSPACE}/change
             -Dvitruv.framework.path=${GITHUB_WORKSPACE}/framework
             -Dvitruv.dsls.path=${GITHUB_WORKSPACE}/dsls
             -Dstyle.color=always

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
     types: [created]
   schedule:
     - cron: '0 2 30 * *' # run nightly at 2:30 am
+  workflow_call:
 
 jobs:
   build:
@@ -37,6 +38,13 @@ jobs:
           -Dorg.apache.commons.logging.Log=org.apache.commons.logging.impl.NoOpLog
         env: 
           MAVEN_OPTS: -Djansi.force=true
+      - name: Store Change Artifact
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v3
+        with:
+          name: change
+          path: releng/tools.vitruv.change.updatesite/target/repository
+          retention-days: 1
       - name: Publish Nightly Update Site
         if: github.ref == 'refs/heads/main' && github.repository_owner == 'vitruv-tools'
         uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,6 @@ on:
     branches: [main]
   release:
     types: [created]
-  pull_request:
   schedule:
     - cron: '0 2 30 * *' # run nightly at 2:30 am
 

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -6,39 +6,7 @@ on:
 jobs:
   build_change:
     name: Change
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Change
-        uses: actions/checkout@v3
-      - name: Cache
-        uses: actions/cache@v3
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml', '**/MANIFEST.MF') }}
-          restore-keys: ${{ runner.os }}-m2
-      - name: Set up JDK
-        uses: actions/setup-java@v2
-        with:
-          distribution: 'zulu'
-          java-version: 11
-      - name: Build and Verify Change
-        run: >
-          ./mvnw -B -U clean verify
-          -Dstyle.color=always
-          -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
-          -Dorg.slf4j.simpleLogger.log.org.eclipse.tycho.core.resolver.DefaultTychoResolver=warn
-          -Dorg.slf4j.simpleLogger.log.org.eclipse.tycho.osgi.configuration.MavenContextConfigurator=warn
-          -Dorg.slf4j.simpleLogger.log.org.eclipse.sisu.equinox.launching.internal.DefaultEquinoxLauncher=warn
-          -Dorg.slf4j.simpleLogger.log.org.eclipse.xtext.maven.XtextGenerateMojo=warn
-          -Dorg.apache.commons.logging.Log=org.apache.commons.logging.impl.NoOpLog
-        env: 
-          MAVEN_OPTS: -Djansi.force=true
-      - name: Store Change Artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: change
-          path: releng/tools.vitruv.change.updatesite/target/repository
-          retention-days: 1
+    uses: ./.github/workflows/ci.yml
           
   validate_framework:
     needs: build_change
@@ -57,7 +25,7 @@ jobs:
           repository: vitruv-tools/Vitruv
           ref: main
           fetch-depth: 0
-      - name: Checkout Matching Framework Branches
+      - name: Checkout Matching Framework Branch
         run: |
           cd framework
           git checkout -B ${{ github.head_ref }} origin/${{ github.head_ref }} || true
@@ -115,7 +83,7 @@ jobs:
           repository: vitruv-tools/Vitruv-DSLs
           ref: main
           fetch-depth: 0
-      - name: Checkout Matching DSLs Branches
+      - name: Checkout Matching DSLs Branch
         run: |
           cd dsls
           git checkout -B ${{ github.head_ref }} origin/${{ github.head_ref }} || true
@@ -181,7 +149,7 @@ jobs:
           repository: vitruv-tools/Vitruv-Applications-ComponentBasedSystems
           ref: main
           fetch-depth: 0
-      - name: Checkout Matching Applications Branches
+      - name: Checkout Matching Applications Branch
         run: |
           cd cbsapplications
           git checkout -B ${{ github.head_ref }} origin/${{ github.head_ref }} || true

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -1,16 +1,15 @@
-name: Application Validation
+name: Validation
 
 on:
   pull_request:
 
 jobs:
   build_change:
+    name: Change
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Change
         uses: actions/checkout@v3
-        with:
-          path: change
       - name: Cache
         uses: actions/cache@v3
         with:
@@ -22,10 +21,9 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: 11
-      - name: Build Change
-        working-directory: ./change
+      - name: Build and Verify Change
         run: >
-          ./mvnw -B -U package -Dmaven.test.skip=true
+          ./mvnw -B -U clean verify
           -Dstyle.color=always
           -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
           -Dorg.slf4j.simpleLogger.log.org.eclipse.tycho.core.resolver.DefaultTychoResolver=warn
@@ -39,11 +37,12 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: change
-          path: change/releng/tools.vitruv.change.updatesite/target/repository
+          path: releng/tools.vitruv.change.updatesite/target/repository
           retention-days: 1
           
   validate_framework:
     needs: build_change
+    name: Framework
     runs-on: ubuntu-latest
     steps:
       - name: Download Change Artifact
@@ -73,11 +72,11 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: 11
-      - name: Build Framework
+      - name: Build and Verify Framework
         working-directory: ./framework
         run: >
           ./mvnw -B -U clean verify
-          -Dvitruv.change.url="file:///\${GITHUB_WORKSPACE}/change"
+          -Dvitruv.change.url=file:///${{ github.workspace }}/change
           -Dstyle.color=always
           -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
           -Dorg.slf4j.simpleLogger.log.org.eclipse.tycho.core.resolver.DefaultTychoResolver=warn
@@ -96,6 +95,7 @@ jobs:
 
   validate_DSLs:
     needs: [build_change, validate_framework]
+    name: DSLs
     runs-on: ubuntu-latest
     steps:
       - name: Download Change Artifact
@@ -130,14 +130,14 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: 11
-      - name: Build DSLs
+      - name: Build and Verify DSLs
         uses: GabrielBB/xvfb-action@v1
         with:
           working-directory: ./dsls
           run: >
             ./mvnw -B -U clean verify
-            -Dvitruv.change.url=file:///${GITHUB_WORKSPACE}/change
-            -Dvitruv.framework.url=file:///${GITHUB_WORKSPACE}/framework
+            -Dvitruv.change.url=file:///${{ github.workspace }}/change
+            -Dvitruv.framework.url=file:///${{ github.workspace }}/framework
             -Dstyle.color=always
             -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
             -Dorg.slf4j.simpleLogger.log.org.eclipse.tycho.core.resolver.DefaultTychoResolver=warn
@@ -156,6 +156,7 @@ jobs:
 
   validate_cbs_applications:
     needs: [build_change, validate_framework, validate_DSLs]
+    name: Applications
     runs-on: ubuntu-latest
     steps:
       - name: Download Change Artifact
@@ -195,15 +196,15 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: 11
-      - name: Build Applications
+      - name: Build and Verify Applications
         uses: GabrielBB/xvfb-action@v1
         with:
           working-directory: ./cbsapplications
           run: >
             ./mvnw -B -U clean verify
-            -Dvitruv.change.url=file:///${GITHUB_WORKSPACE}/change
-            -Dvitruv.framework.url=file:///${GITHUB_WORKSPACE}/framework
-            -Dvitruv.dsls.url=file:///${GITHUB_WORKSPACE}/dsls
+            -Dvitruv.change.url=file:///${{ github.workspace }}/change
+            -Dvitruv.framework.url=file:///${{ github.workspace }}/framework
+            -Dvitruv.dsls.url=file:///${{ github.workspace }}/dsls
             -Dstyle.color=always
             -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
             -Dorg.slf4j.simpleLogger.log.org.eclipse.tycho.core.resolver.DefaultTychoResolver=warn

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -4,12 +4,12 @@ on:
   pull_request:
 
 jobs:
-  build_change:
+  validate_change:
     name: Change
     uses: ./.github/workflows/ci.yml
           
   validate_framework:
-    needs: build_change
+    needs: validate_change
     name: Framework
     runs-on: ubuntu-latest
     steps:
@@ -62,7 +62,7 @@ jobs:
           retention-days: 1
 
   validate_DSLs:
-    needs: [build_change, validate_framework]
+    needs: [validate_change, validate_framework]
     name: DSLs
     runs-on: ubuntu-latest
     steps:
@@ -123,7 +123,7 @@ jobs:
           retention-days: 1
 
   validate_cbs_applications:
-    needs: [build_change, validate_framework, validate_DSLs]
+    needs: [validate_change, validate_framework, validate_DSLs]
     name: Applications
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This PR refactors the GitHub actions to run each dependency validation (Framework, DSLs, CBS-Applications) as a separate job. As some repositories depend on others, these dependencies are made explicit using `job.needs` and build artifacts (the Maven repository) are shared between jobs using GitHub artifacts.
As each repository is validated as a separate job, the overview now lists each repository individually, thus it is easier to follow which repository caused a build failure.
Furthermore, the duplication of the Change repository build was removed and replaced by calling the CI workflow from within the validation workflow, thus reusing the ci.yaml code for the validation.

Unfortunately, GitHub provides no built-in way to purge artifacts after a workflow finished. [There are workarounds](https://github.com/marketplace/actions/delete-run-artifacts) but they require a high configuration overhead which I don't consider worth it. Thus, the actions are configured to keep the build artifacts (`updatesite/target/repsitory` of Change, Framework, and DSLs) for one day (minimum possible value).

⚠️ Before merging, the branch protection rules need to be adjusted.