### PR TITLE
Ensure that models created by applying changes are monitored

### DIFF
--- a/bundles/tools.vitruv.change.propagation/src/tools/vitruv/change/propagation/impl/DefaultChangeRecordingModelRepository.java
+++ b/bundles/tools.vitruv.change.propagation/src/tools/vitruv/change/propagation/impl/DefaultChangeRecordingModelRepository.java
@@ -4,6 +4,8 @@ import org.apache.log4j.Logger;
 import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
 
+import com.google.common.collect.FluentIterable;
+
 import tools.vitruv.change.composite.description.TransactionalChange;
 import tools.vitruv.change.composite.description.VitruviusChange;
 import tools.vitruv.change.composite.recording.ChangeRecorder;
@@ -170,6 +172,8 @@ public class DefaultChangeRecordingModelRepository implements PersistableChangeR
 
 	@Override
 	public VitruviusChange applyChange(VitruviusChange change) {
+		// Ensure all resources for changed elements are created/loaded and change monitors are initialized
+		FluentIterable.from(change.getChangedURIs()).forEach(uri -> getModelResource(uri));
 		return change.resolveAndApply(modelsResourceSet);
 	}
 


### PR DESCRIPTION
The `DefaultChangeRecordingModelRepository` did only register the change recorder for resources that were explicitly retrieved by calling `getModelResource`. All resources that are created by applying changes to the repository by calling `applyChanges` were not monitored. This is not a problem if no changes are expected in these models (like it was by now), but if these models may also be changed (due to bidirectional execution of change propagation), the monitored changes are wrong.
This PR fixes the problem by explicitly creating resources for changes passed to `applyChanges` as well.