### PR TITLE
Remove faulty bypass of registering change recorder to retrieved resource

### DIFF
--- a/bundles/tools.vitruv.change.propagation/src/tools/vitruv/change/propagation/impl/DefaultChangeRecordingModelRepository.java
+++ b/bundles/tools.vitruv.change.propagation/src/tools/vitruv/change/propagation/impl/DefaultChangeRecordingModelRepository.java
@@ -89,16 +89,7 @@ public class DefaultChangeRecordingModelRepository implements PersistableChangeR
 		return getCreateOrLoadModel(uri);
 	}
 
-	private Resource getCreateOrLoadModel(URI modelURI) {
-		Resource existingResource = modelsResourceSet.getResource(modelURI, false);
-		if (existingResource != null) {
-			return existingResource;
-		} else {
-			return createOrLoadModelResource(modelURI);
-		}
-	}
-
-	private Resource createOrLoadModelResource(URI modelResourceURI) {
+	private Resource getCreateOrLoadModel(URI modelResourceURI) {
 		Resource resource;
 		if ((modelResourceURI.isFile() || modelResourceURI.isPlatform())) {
 			resource = getOrCreateResource(modelsResourceSet, modelResourceURI);


### PR DESCRIPTION
The `DefaultChangeRecordingModelRepository` had an unnecessary bypass for retrieving, loading or creating a resource when it is already present in the resource set, which led to just created resources not being recorded for changes (in contrast to the purpose of the class). This PR removes the unnecessary bypass and fixes that bug.

Replaces and closes #29.