### PR TITLE
Correct CI nightly build schedule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
   release:
     types: [created]
   schedule:
-    - cron: '0 2 30 * *' # run nightly at 2:30 am
+    - cron: '30 2 * * *' # run nightly at 2:30 am
   workflow_call:
 
 jobs:


### PR DESCRIPTION
Corrects the nightly build schedule to run at 2:30AM instead of 2:00AM only on the 30th of the month 😄
[POSIX cron syntax](https://pubs.opengroup.org/onlinepubs/9699919799/utilities/crontab.html#tag_20_25_07)