### PR TITLE
Setup Dependabot for GitHub actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+      time: "11:00"
+      timezone: "Europe/Berlin"
+    commit-message:
+      prefix: "GitHub Actions"
+      include: "scope"


### PR DESCRIPTION
Sets up GitHub Dependabot to automatically update dependencies of GitHub actions. Updates are checked once a week (Wednesday 11:00 AM).