### PR TITLE
Interface and Code cleanup

### DIFF
--- a/bundles/tools.vitruv.change.correspondence/src/tools/vitruv/change/correspondence/model/PersistableCorrespondenceModelImpl.java
+++ b/bundles/tools.vitruv.change.correspondence/src/tools/vitruv/change/correspondence/model/PersistableCorrespondenceModelImpl.java
@@ -26,10 +26,10 @@ import static com.google.common.base.Preconditions.checkState;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EObject;
 
-public class PersistableCorrespondenceModelImpl implements PersistableCorrespondenceModel {
-	static Logger logger = Logger.getLogger(PersistableCorrespondenceModelImpl.class);
-	final Correspondences correspondences;
-	final Resource correspondencesResource;
+class PersistableCorrespondenceModelImpl implements PersistableCorrespondenceModel {
+	private static final Logger logger = Logger.getLogger(PersistableCorrespondenceModelImpl.class);
+	private final Correspondences correspondences;
+	private final Resource correspondencesResource;
 
 	public PersistableCorrespondenceModelImpl(URI resourceUri) {
 		this.correspondences = CorrespondenceFactory.eINSTANCE.createCorrespondences();

--- a/bundles/tools.vitruv.change.propagation/src/tools/vitruv/change/propagation/impl/AbstractChangePropagationSpecification.xtend
+++ b/bundles/tools.vitruv.change.propagation/src/tools/vitruv/change/propagation/impl/AbstractChangePropagationSpecification.xtend
@@ -8,7 +8,7 @@ import org.eclipse.emf.ecore.EObject
 import tools.vitruv.change.composite.MetamodelDescriptor
 
 abstract class AbstractChangePropagationSpecification implements ChangePropagationSpecification {
-	val List<ChangePropagationObserver> propagationObserver;
+	val List<ChangePropagationObserver> propagationObservers;
 	var UserInteractor userInteractor;
 	var MetamodelDescriptor sourceMetamodelDescriptor;
 	var MetamodelDescriptor targetMetamodelDescriptor;
@@ -16,7 +16,7 @@ abstract class AbstractChangePropagationSpecification implements ChangePropagati
 	new(MetamodelDescriptor sourceMetamodelDescriptor, MetamodelDescriptor targetMetamodelDescriptor) {
 		this.sourceMetamodelDescriptor = sourceMetamodelDescriptor
 		this.targetMetamodelDescriptor = targetMetamodelDescriptor
-		this.propagationObserver = newArrayList();
+		this.propagationObservers = newArrayList();
 	}
 
 	protected def UserInteractor getUserInteractor() {
@@ -37,16 +37,16 @@ abstract class AbstractChangePropagationSpecification implements ChangePropagati
 
 	override registerObserver(ChangePropagationObserver observer) {
 		if (observer !== null) {
-			this.propagationObserver += observer;
+			this.propagationObservers += observer;
 		}
 	}
 
 	override deregisterObserver(ChangePropagationObserver observer) {
-		this.propagationObserver -= observer;
+		this.propagationObservers -= observer;
 	}
 
 	override notifyObjectCreated(EObject createdObject) {
-		this.propagationObserver.forEach[it.objectCreated(createdObject)];
+		this.propagationObservers.forEach[it.objectCreated(createdObject)];
 	}
 
 }

--- a/bundles/tools.vitruv.change.propagation/src/tools/vitruv/change/propagation/impl/ChangePropagator.xtend
+++ b/bundles/tools.vitruv.change.propagation/src/tools/vitruv/change/propagation/impl/ChangePropagator.xtend
@@ -31,33 +31,34 @@ class ChangePropagator {
 	val ChangeRecordingModelRepository modelRepository
 	val ChangePropagationSpecificationProvider changePropagationProvider
 	val InternalUserInteractor userInteractor
-	var ChangePropagationMode changePropagationMode = ChangePropagationMode.TRANSITIVE_CYCLIC
+	val ChangePropagationMode changePropagationMode
+	
+	/**
+	 * Creates a change propagator to which changes can be passed, which are
+	 * propagated using the given <code>changePropagationProvider</code> and
+	 * <code>userInteractor</code>.
+	 * Changes are recorded in the given <code>modelRepository</code> and
+	 * propagated transitively and cyclic, i.e. with 
+	 * {@link ChangePropagationMode#TRANSITIVE_CYCLIC}.
+	 */
+	new(ChangeRecordingModelRepository modelRepository,
+		ChangePropagationSpecificationProvider changePropagationProvider, InternalUserInteractor userInteractor) {
+		this(modelRepository, changePropagationProvider, userInteractor, ChangePropagationMode.TRANSITIVE_CYCLIC)
+	}
 	
 	/**
 	 * Creates a change propagator to which changes can be passed, which are
 	 * propagated using the given <code>changePropagationProvider</code> and
 	 * <code>userInteractor</code>.
 	 * By default, it records changes in the given <code>modelRepository</code> and
-	 * propagates them transitively and cyclic, i.e. with 
-	 * {@link ChangePropagationMode#TRANSITIVE_CYCLIC}. It can be changed calling
-	 * {@link #setChangePropagationMode(ChangePropagationMode)}.
-	 * 
+	 * propagates them using the given <code>mode</code>.
 	 */
 	new(ChangeRecordingModelRepository modelRepository,
-		ChangePropagationSpecificationProvider changePropagationProvider, InternalUserInteractor userInteractor) {
+		ChangePropagationSpecificationProvider changePropagationProvider, InternalUserInteractor userInteractor, ChangePropagationMode mode) {
 		this.modelRepository = modelRepository
 		this.changePropagationProvider = changePropagationProvider
 		this.userInteractor = userInteractor
-	}
-	
-	/**
-	 * Sets the propagation mode to only perform single transformation steps
-	 * or different kinds of transitive change propagation.
-	 * 
-	 * @param mode the mode to use for change propagation
-	 */
-	def void setChangePropagationMode(ChangePropagationMode mode) {
-		changePropagationMode = mode
+		this.changePropagationMode = mode
 	}
 	
 	def List<PropagatedChange> propagateChange(VitruviusChange change) {

--- a/bundles/tools.vitruv.change.propagation/src/tools/vitruv/change/propagation/impl/DefaultChangeRecordingModelRepository.java
+++ b/bundles/tools.vitruv.change.propagation/src/tools/vitruv/change/propagation/impl/DefaultChangeRecordingModelRepository.java
@@ -1,6 +1,20 @@
 package tools.vitruv.change.propagation.impl;
 
+import static edu.kit.ipd.sdq.commons.util.org.eclipse.emf.ecore.resource.ResourceSetUtil.getOrCreateResource;
+import static edu.kit.ipd.sdq.commons.util.org.eclipse.emf.ecore.resource.ResourceSetUtil.loadOrCreateResource;
+import static edu.kit.ipd.sdq.commons.util.org.eclipse.emf.ecore.resource.ResourceSetUtil.withGlobalFactories;
+import static tools.vitruv.change.correspondence.model.CorrespondenceModelFactory.createPersistableCorrespondenceModel;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
 import org.apache.log4j.Logger;
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
 
@@ -12,21 +26,6 @@ import tools.vitruv.change.correspondence.model.PersistableCorrespondenceModel;
 import tools.vitruv.change.correspondence.view.CorrespondenceModelViewFactory;
 import tools.vitruv.change.correspondence.view.EditableCorrespondenceModelView;
 import tools.vitruv.change.propagation.PersistableChangeRecordingModelRepository;
-
-import static edu.kit.ipd.sdq.commons.util.org.eclipse.emf.ecore.resource.ResourceSetUtil.withGlobalFactories;
-import static edu.kit.ipd.sdq.commons.util.org.eclipse.emf.ecore.resource.ResourceSetUtil.getOrCreateResource;
-import static edu.kit.ipd.sdq.commons.util.org.eclipse.emf.ecore.resource.ResourceSetUtil.loadOrCreateResource;
-import static tools.vitruv.change.correspondence.model.CorrespondenceModelFactory.createPersistableCorrespondenceModel;
-
-import java.io.IOException;
-import java.nio.file.Path;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-
-import org.eclipse.emf.common.util.URI;
-import org.eclipse.emf.ecore.EObject;
-import org.eclipse.emf.ecore.resource.Resource;
 
 /**
  * A default implementation of a {@link PersistableChangeRecordingModelRepository}. It manages a {@link ResourceSet} for
@@ -103,7 +102,7 @@ public class DefaultChangeRecordingModelRepository implements PersistableChangeR
 
 	@Override
 	public void persistAsRoot(EObject rootEObject, URI uri) {
-		addRoot(getCreateOrLoadModel(uri), (rootEObject));
+		addRoot(getCreateOrLoadModel(uri), rootEObject);
 	}
 
 	private void addRoot(Resource resource, EObject root) {
@@ -122,7 +121,7 @@ public class DefaultChangeRecordingModelRepository implements PersistableChangeR
 				save(modelResource);
 			}
 		}
-		resourcesToDelete.stream().forEach((resource) -> delete(resource));
+		resourcesToDelete.stream().forEach(this::delete);
 		correspondenceModel.save();
 	}
 


### PR DESCRIPTION
This PR cleans up some interfaces and fixes bad code formatting
Relevant:
- Make `changePropagationMode` of `ChangePropagator` not mutable anymore but require it as constructor parameter
  - Change was done as a change propagator should only live for the duration of one change propagation. This will become mandatory when supporting versions, as the propagator's `ChangeRecordingModelRepository` will be a different instance for each change propagation
- Adapt visibility of `PersistableCorrespondenceModelImpl` to `package`