### PR TITLE
track cascade deletion in change recorder

### DIFF
--- a/bundles/tools.vitruv.change.composite/src/tools/vitruv/change/composite/recording/ChangeRecorder.xtend
+++ b/bundles/tools.vitruv.change.composite/src/tools/vitruv/change/composite/recording/ChangeRecorder.xtend
@@ -191,7 +191,7 @@ class ChangeRecorder implements AutoCloseable {
 				switch (eChange) {
 					EObjectSubtractedEChange<?> case eChange.isContainmentRemoval &&
 						removedElements.contains(eChange.oldValue):
-						converter.createDeleteChange(eChange)
+						converter.createDeleteChanges(eChange)
 					default:
 						null
 				}
@@ -208,7 +208,7 @@ class ChangeRecorder implements AutoCloseable {
 	 */
 	def private static List<EChange> insertChanges(
 		List<EChange> changes,
-		(EChange)=>EChange inserter
+		(EChange)=>List<EChange> inserter
 	) {
 		var List<EChange> resultEChanges = null
 		for (var k = 0; k < changes.size; k++) {
@@ -217,10 +217,10 @@ class ChangeRecorder implements AutoCloseable {
 			val additional = inserter.apply(eChange)
 			if (additional !== null) {
 				if (resultEChanges === null) {
-					resultEChanges = new ArrayList(changes.size + 1)
+					resultEChanges = new ArrayList(changes.size + additional.size)
 					resultEChanges.addAll(changes.subList(0, k + 1))
 				}
-				resultEChanges.add(additional)
+				resultEChanges += additional
 			}
 		}
 		return if (resultEChanges !== null) {

--- a/bundles/tools.vitruv.change.composite/src/tools/vitruv/change/composite/recording/NotificationToEChangeConverter.xtend
+++ b/bundles/tools.vitruv.change.composite/src/tools/vitruv/change/composite/recording/NotificationToEChangeConverter.xtend
@@ -1,20 +1,22 @@
 package tools.vitruv.change.composite.recording
 
 import java.util.List
+import org.eclipse.emf.common.util.URI
+import org.eclipse.emf.ecore.EAttribute
 import org.eclipse.emf.ecore.EObject
-import tools.vitruv.change.atomic.EChange
-import tools.vitruv.change.atomic.feature.attribute.AttributeFactory
-import tools.vitruv.change.atomic.TypeInferringAtomicEChangeFactory
 import org.eclipse.emf.ecore.EReference
 import org.eclipse.emf.ecore.resource.Resource
+import org.eclipse.xtend.lib.annotations.FinalFieldsConstructor
+import tools.vitruv.change.atomic.EChange
+import tools.vitruv.change.atomic.TypeInferringAtomicEChangeFactory
 import tools.vitruv.change.atomic.eobject.EObjectAddedEChange
 import tools.vitruv.change.atomic.eobject.EObjectSubtractedEChange
-import static org.eclipse.emf.common.notify.Notification.*
-import static extension edu.kit.ipd.sdq.commons.util.java.lang.IterableUtil.*
-import org.eclipse.xtend.lib.annotations.FinalFieldsConstructor
-import org.eclipse.emf.ecore.EAttribute
-import org.eclipse.emf.common.util.URI
+import tools.vitruv.change.atomic.feature.attribute.AttributeFactory
 import tools.vitruv.change.atomic.feature.reference.UpdateReferenceEChange
+
+import static org.eclipse.emf.common.notify.Notification.*
+
+import static extension edu.kit.ipd.sdq.commons.util.java.lang.IterableUtil.*
 import static extension tools.vitruv.change.composite.recording.EChangeCreationUtil.*
 
 /** 
@@ -27,9 +29,10 @@ package final class NotificationToEChangeConverter {
 	
 	val (EObject, EObject)=>boolean isCreateChange
 
-	def createDeleteChange(EObjectSubtractedEChange<?> change) {
-		val deleteChange = createDeleteEObjectChange(change.oldValue)
-		return deleteChange
+	def List<EChange> createDeleteChanges(EObjectSubtractedEChange<?> change) {
+		var allDeletedElements = change.oldValue.eAllContents.toList.reverse //delete from inner to outer
+		allDeletedElements.add(change.oldValue)
+		return allDeletedElements.mapFixed[createDeleteEObjectChange]
 	}
 	
 	/** 

--- a/tests/tools.vitruv.change.composite.tests/src/tools/vitruv/change/composite/recording/ChangeRecorderTest.xtend
+++ b/tests/tools.vitruv.change.composite.tests/src/tools/vitruv/change/composite/recording/ChangeRecorderTest.xtend
@@ -191,7 +191,7 @@ class ChangeRecorderTest {
 			resource.contents.clear()
 		]
 
-		assertThat(changeRecorder.change, hasEChanges(RemoveRootEObject, DeleteEObject))
+		assertThat(changeRecorder.change, hasEChanges(RemoveRootEObject, DeleteEObject, DeleteEObject, DeleteEObject, DeleteEObject))
 	}
 
 	@DisplayName("adds an object set as containment to the recording")
@@ -367,7 +367,7 @@ class ChangeRecorderTest {
 		record [
 			resource.delete(emptyMap)
 		]
-		assertThat(changeRecorder.change, hasEChanges(RemoveRootEObject, DeleteEObject))
+		assertThat(changeRecorder.change, hasEChanges(RemoveRootEObject, DeleteEObject, DeleteEObject))
 	}
 
 	@ParameterizedTest(name="while isRecording={0}")

--- a/tests/tools.vitruv.change.composite.tests/src/tools/vitruv/change/composite/reference/ChangeDescription2RemoveEReferenceTest.xtend
+++ b/tests/tools.vitruv.change.composite.tests/src/tools/vitruv/change/composite/reference/ChangeDescription2RemoveEReferenceTest.xtend
@@ -137,7 +137,7 @@ class ChangeDescription2RemoveEReferenceTest extends ChangeDescription2ChangeTra
 		]
 
 		// assert
-		result.assertChangeCount(4)
+		result.assertChangeCount(5)
 			.assertReplaceAndDeleteNonRoot(containedRoot, uniquePersistedRoot, ROOT__RECURSIVE_ROOT, false)
 			.assertReplaceSingleValuedEReference(innerContainedRoot, ROOT__SINGLE_VALUED_CONTAINMENT_EREFERENCE, nonRoot, null, true, false, false)
 			.assertReplaceSingleValuedEReference(uniquePersistedRoot, ROOT__SINGLE_VALUED_CONTAINMENT_EREFERENCE, null, nonRoot, true, false, false)

--- a/tests/tools.vitruv.change.composite.tests/src/tools/vitruv/change/composite/util/CompoundEChangeAssertHelper.xtend
+++ b/tests/tools.vitruv.change.composite.tests/src/tools/vitruv/change/composite/util/CompoundEChangeAssertHelper.xtend
@@ -42,9 +42,13 @@ class CompoundEChangeAssertHelper {
 	
 	def static Iterable<? extends EChange> assertReplaceAndDeleteNonRoot(Iterable<? extends EChange> changes, EObject expectedOldValue,
 		EObject affectedEObject, EStructuralFeature affectedFeature, boolean isUnset) {
-		changes.assertSizeGreaterEquals(2)
-		return changes.assertReplaceSingleValuedEReference(affectedEObject, affectedFeature, expectedOldValue, null, true, false, isUnset)
-			.assertDeleteEObject(expectedOldValue)
+		val deletedContainedElements = expectedOldValue.eAllContents.toList.reverse // elements are deleted from inner to outer
+		changes.assertSizeGreaterEquals(2 + deletedContainedElements.size)
+		var filteredChanges = changes.assertReplaceSingleValuedEReference(affectedEObject, affectedFeature, expectedOldValue, null, true, false, isUnset)
+		for (deletedContainedElement : deletedContainedElements) {
+			filteredChanges = filteredChanges.assertDeleteEObject(deletedContainedElement)
+		}
+		return filteredChanges.assertDeleteEObject(expectedOldValue)
 	}
 
 	def static Iterable<? extends EChange> assertCreateAndInsertRootEObject(Iterable<? extends EChange> changes, EObject expectedNewValue, String uri, Resource resource) {


### PR DESCRIPTION
This PR adapts the `ChangeRecorder` to create delete changes not only for the element actually deleted, but for all elements that are cascade deleted by it.
As an example, if I have an element `a` which contains element `b` and I delete `a`, both `a` and `b` are deleted since `a` is the container of `b`. As of now, we didn't explicitly track the deletion of `b`.

As a conceptual motivation we can argue that our change sequence should describe the entire model state change and thus make cascade deletions explicit. From a more practical motivation, we need these changes to replay change sequences backwards. Currently, due to the use of hierarchical IDs this problem is made transparent, i.e. the tests still succeed although some element IDs cannot be resolved. However, as soon as we migrate to UUIDs this is not the case anymore as no UUID is registered for a cascade deleted element when replaying changes backwards.