### PR TITLE
Migrate to Eclipse 2022-12 and Java 17

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -3,6 +3,6 @@
   <extension>
     <groupId>org.eclipse.tycho</groupId>
     <artifactId>tycho-build</artifactId>
-    <version>3.0.0</version>
+    <version>3.0.1</version>
   </extension>
 </extensions>

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -3,6 +3,6 @@
   <extension>
     <groupId>org.eclipse.tycho</groupId>
     <artifactId>tycho-build</artifactId>
-    <version>2.7.4</version>
+    <version>3.0.0</version>
   </extension>
 </extensions>

--- a/bundles/tools.vitruv.change.atomic/.classpath
+++ b/bundles/tools.vitruv.change.atomic/.classpath
@@ -5,7 +5,7 @@
 			<attribute name="ignore_optional_problems" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17">
 		<attributes>
 			<attribute name="module" value="true"/>
 		</attributes>

--- a/bundles/tools.vitruv.change.atomic/META-INF/MANIFEST.MF
+++ b/bundles/tools.vitruv.change.atomic/META-INF/MANIFEST.MF
@@ -7,7 +7,7 @@ Bundle-Version: 3.0.1.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Export-Package: tools.vitruv.change.atomic,
  tools.vitruv.change.atomic.util,
  tools.vitruv.change.atomic.eobject,

--- a/bundles/tools.vitruv.change.composite/.classpath
+++ b/bundles/tools.vitruv.change.composite/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17">
 		<attributes>
 			<attribute name="module" value="true"/>
 		</attributes>

--- a/bundles/tools.vitruv.change.composite/META-INF/MANIFEST.MF
+++ b/bundles/tools.vitruv.change.composite/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Vitruv Composite Change Metamodel
 Bundle-SymbolicName: tools.vitruv.change.composite
 Automatic-Module-Name: tools.vitruv.change.composite
 Bundle-Version: 3.0.1.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.apache.log4j,
  org.eclipse.xtend.lib,
  org.eclipse.emf.ecore.change,

--- a/bundles/tools.vitruv.change.correspondence/.classpath
+++ b/bundles/tools.vitruv.change.correspondence/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17">
 		<attributes>
 			<attribute name="module" value="true"/>
 		</attributes>

--- a/bundles/tools.vitruv.change.correspondence/META-INF/MANIFEST.MF
+++ b/bundles/tools.vitruv.change.correspondence/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-SymbolicName: tools.vitruv.change.correspondence;singleton:=true
 Automatic-Module-Name: tools.vitruv.change.correspondence
 Bundle-ClassPath: .
 Bundle-Version: 3.0.1.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.apache.log4j,
  org.eclipse.emf.ecore.change,
  edu.kit.ipd.sdq.commons.util.emf,

--- a/bundles/tools.vitruv.change.interaction.model/.classpath
+++ b/bundles/tools.vitruv.change.interaction.model/.classpath
@@ -5,7 +5,7 @@
 			<attribute name="ignore_optional_problems" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17">
 		<attributes>
 			<attribute name="module" value="true"/>
 		</attributes>

--- a/bundles/tools.vitruv.change.interaction.model/META-INF/MANIFEST.MF
+++ b/bundles/tools.vitruv.change.interaction.model/META-INF/MANIFEST.MF
@@ -7,7 +7,7 @@ Bundle-Version: 3.0.1.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Export-Package: tools.vitruv.change.interaction,
  tools.vitruv.change.interaction.util
 Require-Bundle: org.eclipse.emf.ecore;visibility:=reexport,

--- a/bundles/tools.vitruv.change.interaction/.classpath
+++ b/bundles/tools.vitruv.change.interaction/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17">
 		<attributes>
 			<attribute name="module" value="true"/>
 		</attributes>

--- a/bundles/tools.vitruv.change.interaction/META-INF/MANIFEST.MF
+++ b/bundles/tools.vitruv.change.interaction/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Vitruv Change Interactions
 Bundle-SymbolicName: tools.vitruv.change.interaction
 Automatic-Module-Name: tools.vitruv.change.interaction
 Bundle-Version: 3.0.1.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.apache.log4j,
  org.eclipse.swt,

--- a/bundles/tools.vitruv.change.propagation/.classpath
+++ b/bundles/tools.vitruv.change.propagation/.classpath
@@ -5,7 +5,7 @@
 			<attribute name="ignore_optional_problems" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17">
 		<attributes>
 			<attribute name="module" value="true"/>
 		</attributes>

--- a/bundles/tools.vitruv.change.propagation/META-INF/MANIFEST.MF
+++ b/bundles/tools.vitruv.change.propagation/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Vitruv Framework Change Processing
 Bundle-SymbolicName: tools.vitruv.change.propagation;singleton:=true
 Automatic-Module-Name: tools.vitruv.change.propagation
 Bundle-Version: 3.0.1.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.apache.log4j,
  org.eclipse.xtend.lib,
  tools.vitruv.change.correspondence;visibility:=reexport,

--- a/bundles/tools.vitruv.testutils.changevisualization/.classpath
+++ b/bundles/tools.vitruv.testutils.changevisualization/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17">
 		<attributes>
 			<attribute name="module" value="true"/>
 		</attributes>

--- a/bundles/tools.vitruv.testutils.changevisualization/META-INF/MANIFEST.MF
+++ b/bundles/tools.vitruv.testutils.changevisualization/META-INF/MANIFEST.MF
@@ -8,6 +8,6 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.core.resources,
  org.eclipse.core.runtime,
  tools.vitruv.change.composite
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Export-Package: tools.vitruv.testutils.changevisualization
 Bundle-Vendor: vitruv.tools

--- a/bundles/tools.vitruv.testutils.metamodels/.classpath
+++ b/bundles/tools.vitruv.testutils.metamodels/.classpath
@@ -5,7 +5,7 @@
 			<attribute name="ignore_optional_problems" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17">
 		<attributes>
 			<attribute name="module" value="true"/>
 		</attributes>

--- a/bundles/tools.vitruv.testutils.metamodels/META-INF/MANIFEST.MF
+++ b/bundles/tools.vitruv.testutils.metamodels/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-SymbolicName: tools.vitruv.testutils.metamodels;singleton:=true
 Automatic-Module-Name: tools.vitruv.testutils.metamodels
 Bundle-Version: 3.0.1.qualifier
 Bundle-ClassPath: .
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Export-Package: allElementTypes,
  allElementTypes.impl,
  allElementTypes.util,

--- a/bundles/tools.vitruv.testutils/.classpath
+++ b/bundles/tools.vitruv.testutils/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17">
 		<attributes>
 			<attribute name="module" value="true"/>
 		</attributes>

--- a/bundles/tools.vitruv.testutils/META-INF/MANIFEST.MF
+++ b/bundles/tools.vitruv.testutils/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Vitruv Test Utilities
 Bundle-SymbolicName: tools.vitruv.testutils
 Automatic-Module-Name: tools.vitruv.testutils
 Bundle-Version: 3.0.1.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.apache.log4j,
  org.slf4j.api,
  ch.qos.logback.classic,

--- a/releng/tools.vitruv.change.parent/pom.xml
+++ b/releng/tools.vitruv.change.parent/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>tools.vitruv</groupId>
 		<artifactId>parent</artifactId>
-		<version>2.0.2</version>
+		<version>2.1.0</version>
 	</parent>
 	<artifactId>change-parent</artifactId>
 	<version>3.0.1-SNAPSHOT</version>

--- a/releng/tools.vitruv.change.parent/pom.xml
+++ b/releng/tools.vitruv.change.parent/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>tools.vitruv</groupId>
 		<artifactId>parent</artifactId>
-		<version>2.1.0</version>
+		<version>2.1.1</version>
 	</parent>
 	<artifactId>change-parent</artifactId>
 	<version>3.0.1-SNAPSHOT</version>
@@ -16,17 +16,17 @@
 		<repository>
 			<id>Demo Metamodels</id>
 			<layout>p2</layout>
-			<url>https://kit-sdq.github.io/updatesite/release/metamodels/demo/latest/</url>
+			<url>https://kit-sdq.github.io/updatesite/release/metamodels/demo/${sdq.demometamodels.version}</url>
 		</repository>
 		<repository>
 			<id>SDQ Commons</id>
 			<layout>p2</layout>
-			<url>https://kit-sdq.github.io/updatesite/release/commons/latest/</url>
+			<url>https://kit-sdq.github.io/updatesite/release/commons/${sdq.commons.version}</url>
 		</repository>
 		<repository>
 			<id>XAnnotations</id>
 			<layout>p2</layout>
-			<url>https://kit-sdq.github.io/updatesite/release/xannotations/latest/</url>
+			<url>https://kit-sdq.github.io/updatesite/release/xannotations/${sdq.xannotations.version}</url>
 		</repository>
 	</repositories>
 

--- a/releng/tools.vitruv.change.updatesite/category.xml
+++ b/releng/tools.vitruv.change.updatesite/category.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site>
-   C<feature url="features/tools.vitruv.change.feature_3.0.1.qualifier.jar" id="tools.vitruv.change.feature" version="3.0.1.qualifier">
+   <feature url="features/tools.vitruv.change.feature_3.0.1.qualifier.jar" id="tools.vitruv.change.feature" version="3.0.1.qualifier">
       <category name="Vitruv Change"/>
    </feature>
    <feature id="tools.vitruv.change.feature.source" version="3.0.1.qualifier">

--- a/releng/tools.vitruv.change.workflow/.classpath
+++ b/releng/tools.vitruv.change.workflow/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/releng/tools.vitruv.change.workflow/META-INF/MANIFEST.MF
+++ b/releng/tools.vitruv.change.workflow/META-INF/MANIFEST.MF
@@ -5,4 +5,4 @@ Bundle-SymbolicName: tools.vitruv.change.workflow
 Bundle-Version: 3.0.1.qualifier
 Bundle-Vendor: vitruv.tools
 Automatic-Module-Name: tools.vitruv.change.workflow
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/tests/tools.vitruv.change.atomic.tests/.classpath
+++ b/tests/tools.vitruv.change.atomic.tests/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17">
 		<attributes>
 			<attribute name="module" value="true"/>
 		</attributes>

--- a/tests/tools.vitruv.change.atomic.tests/META-INF/MANIFEST.MF
+++ b/tests/tools.vitruv.change.atomic.tests/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-SymbolicName: tools.vitruv.change.atomic.tests
 Automatic-Module-Name: tools.vitruv.change.atomic.tests
 Bundle-Version: 3.0.1.qualifier
 Bundle-Vendor: vitruv.tools
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Fragment-Host: tools.vitruv.change.atomic
 Require-Bundle: org.eclipse.xtend.lib,
  org.junit.jupiter.api,

--- a/tests/tools.vitruv.change.composite.tests/.classpath
+++ b/tests/tools.vitruv.change.composite.tests/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17">
 		<attributes>
 			<attribute name="module" value="true"/>
 		</attributes>

--- a/tests/tools.vitruv.change.composite.tests/META-INF/MANIFEST.MF
+++ b/tests/tools.vitruv.change.composite.tests/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Vitruv Composite Change Metamodel Tests
 Bundle-SymbolicName: tools.vitruv.change.composite.tests
 Automatic-Module-Name: tools.vitruv.change.composite.tests
 Bundle-Version: 3.0.1.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Fragment-Host: tools.vitruv.change.composite
 Require-Bundle: org.eclipse.xtend.lib,
  org.junit.jupiter.api,

--- a/tests/tools.vitruv.change.correspondence.tests/.classpath
+++ b/tests/tools.vitruv.change.correspondence.tests/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src">
 		<attributes>

--- a/tests/tools.vitruv.change.correspondence.tests/META-INF/MANIFEST.MF
+++ b/tests/tools.vitruv.change.correspondence.tests/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-SymbolicName: tools.vitruv.change.correspondence.tests
 Bundle-Version: 3.0.1.qualifier
 Bundle-Vendor: vitruv.tools
 Automatic-Module-Name: tools.vitruv.change.correspondence.tests
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Fragment-Host: tools.vitruv.change.correspondence
 Require-Bundle: com.google.guava,
  org.eclipse.emf.ecore.xmi,

--- a/tests/tools.vitruv.testutils.tests/.classpath
+++ b/tests/tools.vitruv.testutils.tests/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17">
 		<attributes>
 			<attribute name="module" value="true"/>
 		</attributes>

--- a/tests/tools.vitruv.testutils.tests/META-INF/MANIFEST.MF
+++ b/tests/tools.vitruv.testutils.tests/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Vitruv Test Utilities Tests
 Bundle-SymbolicName: tools.vitruv.testutils.tests
 Bundle-Version: 3.0.1.qualifier
 Automatic-Module-Name: tools.vitruv.testutils.tests
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-Vendor: vitruv.tools
 Require-Bundle: tools.vitruv.testutils,
  tools.vitruv.testutils.metamodels,


### PR DESCRIPTION
Updates dependencies to Eclipse 2022-12 and migrates to JavaSE-17.
Pins SDQ dependency versions to version specified in parent pom.

There is a problem when using Xtend 2.29.0 within Eclipse. In particular, imports are marked as "not accessible" and result in a build failure. I am currently investigating this problem. However, it will occur independent of merging this PR thus should not be a blocker for it.
A hotfix is to change the severity of forbidden references in Xtend to the level of a warning which I will document in the Wiki, and create an issue for it.