### PR TITLE
Fix Xtend error

### DIFF
--- a/bundles/tools.vitruv.change.correspondence/src/tools/vitruv/change/correspondence/model/PersistableCorrespondenceModelImpl.java
+++ b/bundles/tools.vitruv.change.correspondence/src/tools/vitruv/change/correspondence/model/PersistableCorrespondenceModelImpl.java
@@ -1,15 +1,7 @@
 package tools.vitruv.change.correspondence.model;
 
-import org.apache.log4j.Logger;
-import org.eclipse.emf.common.util.URI;
-import org.eclipse.emf.ecore.resource.Resource;
-import org.eclipse.emf.ecore.resource.ResourceSet;
-import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
-import org.eclipse.emf.ecore.util.EcoreUtil;
-
-import tools.vitruv.change.correspondence.Correspondence;
-import tools.vitruv.change.correspondence.CorrespondenceFactory;
-import tools.vitruv.change.correspondence.Correspondences;
+import static com.google.common.base.Preconditions.checkState;
+import static edu.kit.ipd.sdq.commons.util.org.eclipse.emf.ecore.resource.ResourceSetUtil.loadOrCreateResource;
 import static edu.kit.ipd.sdq.commons.util.org.eclipse.emf.ecore.resource.ResourceSetUtil.withGlobalFactories;
 
 import java.io.IOException;
@@ -20,11 +12,18 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static edu.kit.ipd.sdq.commons.util.org.eclipse.emf.ecore.resource.ResourceSetUtil.loadOrCreateResource;
-import static com.google.common.base.Preconditions.checkState;
-
+import org.apache.log4j.Logger;
+import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.emf.ecore.resource.ResourceSet;
+import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
+import org.eclipse.emf.ecore.util.EcoreUtil;
+
+import tools.vitruv.change.correspondence.Correspondence;
+import tools.vitruv.change.correspondence.CorrespondenceFactory;
+import tools.vitruv.change.correspondence.Correspondences;
 
 class PersistableCorrespondenceModelImpl implements PersistableCorrespondenceModel {
 	private static final Logger logger = Logger.getLogger(PersistableCorrespondenceModelImpl.class);
@@ -63,7 +62,7 @@ class PersistableCorrespondenceModelImpl implements PersistableCorrespondenceMod
 	}
 
 	private static List<EObject> resolve(List<EObject> eObjects, ResourceSet resolveIn) {
-		List<EObject> resolvedEObjects = eObjects.stream().map(eObject -> EcoreUtil.resolve(eObject, resolveIn)).collect(Collectors.toList());
+		List<EObject> resolvedEObjects = eObjects.stream().map(eObject -> EcoreUtil.resolve(eObject, resolveIn)).toList();
 		for (EObject resolvedEObject : resolvedEObjects) {
 			checkState(!resolvedEObject.eIsProxy(), "object %s is referenced in correspondence but could not be resolved", resolvedEObject);
 		}
@@ -104,7 +103,7 @@ class PersistableCorrespondenceModelImpl implements PersistableCorrespondenceMod
 						"Correspondence between %s and %s contains elements %s that are not contained in a resource anymore.",
 						element.getLeftEObjects(), element.getRightEObjects(),
 						Stream.concat(element.getLeftEObjects().stream(), element.getRightEObjects().stream()).filter(this::isNotInManagedResource)
-								.collect(Collectors.toList()));
+								.toList());
 				iterator.remove();
 				if (logger.isTraceEnabled()) {
 					logger.trace("Correspondence between " + element.getLeftEObjects() + " and " + element.getRightEObjects()

--- a/bundles/tools.vitruv.testutils.metamodels/.classpath
+++ b/bundles/tools.vitruv.testutils.metamodels/.classpath
@@ -10,6 +10,7 @@
 			<attribute name="module" value="true"/>
 		</attributes>
 	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/5"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="src" path="xtend-gen">

--- a/bundles/tools.vitruv.testutils/.classpath
+++ b/bundles/tools.vitruv.testutils/.classpath
@@ -5,6 +5,7 @@
 			<attribute name="module" value="true"/>
 		</attributes>
 	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/5"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="src" path="xtend-gen">

--- a/tests/tools.vitruv.change.atomic.tests/.classpath
+++ b/tests/tools.vitruv.change.atomic.tests/.classpath
@@ -5,6 +5,7 @@
 			<attribute name="module" value="true"/>
 		</attributes>
 	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/5"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="src" path="xtend-gen">

--- a/tests/tools.vitruv.change.composite.tests/.classpath
+++ b/tests/tools.vitruv.change.composite.tests/.classpath
@@ -5,6 +5,7 @@
 			<attribute name="module" value="true"/>
 		</attributes>
 	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/5"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="src" path="xtend-gen">

--- a/tests/tools.vitruv.change.correspondence.tests/.classpath
+++ b/tests/tools.vitruv.change.correspondence.tests/.classpath
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/5"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src">
 		<attributes>

--- a/tests/tools.vitruv.testutils.tests/.classpath
+++ b/tests/tools.vitruv.testutils.tests/.classpath
@@ -5,6 +5,7 @@
 			<attribute name="module" value="true"/>
 		</attributes>
 	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/5"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="src" path="xtend-gen"/>


### PR DESCRIPTION
This PR adds JUnit 5 to all test projects' classpaths, thus fixing the Xtend errors occurring with Xtend 2.29 and Eclipse 2022-12.

https://github.com/vitruv-tools/.github/issues/10

Also refactors stream operations to use the Java 16 `toList()` method.