### PR TITLE
Add delete changes at end of change sequence in `ChangeRecorder`

### DIFF
--- a/bundles/tools.vitruv.change.composite/src/tools/vitruv/change/composite/recording/NotificationToEChangeConverter.xtend
+++ b/bundles/tools.vitruv.change.composite/src/tools/vitruv/change/composite/recording/NotificationToEChangeConverter.xtend
@@ -10,7 +10,6 @@ import org.eclipse.xtend.lib.annotations.FinalFieldsConstructor
 import tools.vitruv.change.atomic.EChange
 import tools.vitruv.change.atomic.TypeInferringAtomicEChangeFactory
 import tools.vitruv.change.atomic.eobject.EObjectAddedEChange
-import tools.vitruv.change.atomic.eobject.EObjectSubtractedEChange
 import tools.vitruv.change.atomic.feature.attribute.AttributeFactory
 import tools.vitruv.change.atomic.feature.reference.UpdateReferenceEChange
 
@@ -28,11 +27,9 @@ package final class NotificationToEChangeConverter {
 	extension val TypeInferringAtomicEChangeFactory changeFactory = TypeInferringAtomicEChangeFactory.instance
 	
 	val (EObject, EObject)=>boolean isCreateChange
-
-	def List<EChange> createDeleteChanges(EObjectSubtractedEChange<?> change) {
-		var allDeletedElements = change.oldValue.eAllContents.toList.reverse //delete from inner to outer
-		allDeletedElements.add(change.oldValue)
-		return allDeletedElements.mapFixed[createDeleteEObjectChange]
+	
+	def EChange createDeleteChange(EObject eObject) {
+		return createDeleteEObjectChange(eObject)
 	}
 	
 	/** 

--- a/tests/tools.vitruv.change.composite.tests/src/tools/vitruv/change/composite/reference/ChangeDescription2ReplaceSingleValuedEReferenceTest.xtend
+++ b/tests/tools.vitruv.change.composite.tests/src/tools/vitruv/change/composite/reference/ChangeDescription2ReplaceSingleValuedEReferenceTest.xtend
@@ -45,8 +45,9 @@ class ChangeDescription2ReplaceSingleValuedEReferenceTest extends ChangeDescript
 
 		// assert
 		result.assertChangeCount(4)
-			.assertCreateAndReplaceAndDeleteNonRoot(nonRoot, replaceNonRoot, ROOT__SINGLE_VALUED_CONTAINMENT_EREFERENCE, uniquePersistedRoot, true, false, false)
+			.assertCreateAndReplaceNonRoot(replaceNonRoot, uniquePersistedRoot, nonRoot, ROOT__SINGLE_VALUED_CONTAINMENT_EREFERENCE, false)
 			.assertReplaceSingleValuedEAttribute(replaceNonRoot, IDENTIFIED__ID, null, replaceNonRoot.id, false, false)
+			.assertDeleteEObjectAndContainedElements(nonRoot)
 			.assertEmpty
 	}
 	

--- a/tests/tools.vitruv.change.composite.tests/src/tools/vitruv/change/composite/util/ChangeAssertHelper.xtend
+++ b/tests/tools.vitruv.change.composite.tests/src/tools/vitruv/change/composite/util/ChangeAssertHelper.xtend
@@ -33,11 +33,11 @@ class ChangeAssertHelper {
 
 	static def assertOldValue(EChange eChange, Object oldValue) {
 		if (oldValue instanceof EObject) {
-			assertThat("old value must be the same or a copy than the given old value", oldValue,
+			assertThat("old value must be the same or a copy as the given old value", oldValue,
 				equalsDeeply((eChange as SubtractiveEChange<?>).oldValue as EObject))
 		} else {
 			assertEquals(oldValue, (eChange as SubtractiveEChange<?>).oldValue,
-				"old value must be the same than the given old value")
+				"old value must be the same as the given old value")
 		}
 	}
 
@@ -48,14 +48,14 @@ class ChangeAssertHelper {
 			val newEObject = newValue as EObject
 			var newEObjectInChange = newValueInChange as EObject
 			assertThat(
-				'''new value in change '«newValueInChange»' must be the same than the given new value '«newValue»!''',
+				'''new value in change '«newValueInChange»' must be the same as the given new value '«newValue»!''',
 				newEObject,
 				equalsDeeply(newEObjectInChange)
 			)
 		} else if (!condition) {
 			assertNotNull(newValue)
 			assertEquals(newValue,
-				newValueInChange, '''new value in change '«newValueInChange»' must be the same than the given new value '«newValue»!''')
+				newValueInChange, '''new value in change '«newValueInChange»' must be the same as the given new value '«newValue»!''')
 		}
 	}
 

--- a/tests/tools.vitruv.change.composite.tests/src/tools/vitruv/change/composite/util/CompoundEChangeAssertHelper.xtend
+++ b/tests/tools.vitruv.change.composite.tests/src/tools/vitruv/change/composite/util/CompoundEChangeAssertHelper.xtend
@@ -1,5 +1,6 @@
 package tools.vitruv.change.composite.util
 
+import edu.kit.ipd.sdq.activextendannotations.Utility
 import org.eclipse.emf.ecore.EObject
 import org.eclipse.emf.ecore.EStructuralFeature
 import org.eclipse.emf.ecore.resource.Resource
@@ -7,7 +8,6 @@ import tools.vitruv.change.atomic.EChange
 
 import static extension tools.vitruv.change.composite.util.AtomicEChangeAssertHelper.*
 import static extension tools.vitruv.change.composite.util.ChangeAssertHelper.*
-import edu.kit.ipd.sdq.activextendannotations.Utility
 
 @Utility
 class CompoundEChangeAssertHelper {
@@ -17,34 +17,30 @@ class CompoundEChangeAssertHelper {
 		return changes.assertCreateEObject(expectedNewValue)
 			.assertInsertEReference(affectedEObject, affectedFeature, expectedNewValue,	expectedIndex, true, wasUnset)
 	}
-
-	def static Iterable<? extends EChange> assertRemoveAndDeleteNonRoot(
-			Iterable<? extends EChange> changes, EObject affectedEObject, EStructuralFeature affectedFeature, EObject expectedOldValue, int expectedOldIndex) {
-		changes.assertSizeGreaterEquals(2)
-		return changes.assertRemoveEReference(affectedEObject, affectedFeature, expectedOldValue, expectedOldIndex, true)
-			.assertDeleteEObject(expectedOldValue)
-	}
-	
-	def static Iterable<? extends EChange> assertCreateAndReplaceAndDeleteNonRoot(Iterable<? extends EChange> changes, EObject expectedOldValue,
-			EObject expectedNewValue, EStructuralFeature affectedFeature, EObject affectedEObject, boolean isContainment, boolean wasUnset, boolean isUnset) {
-		changes.assertSizeGreaterEquals(3)
-		return changes.assertCreateEObject(expectedNewValue)
-			.assertReplaceSingleValuedEReference(affectedEObject, affectedFeature, expectedOldValue, expectedNewValue, isContainment, wasUnset, isUnset)
-			.assertDeleteEObject(expectedOldValue)
-	}
 	
 	def static Iterable<? extends EChange> assertCreateAndReplaceNonRoot(Iterable<? extends EChange> changes, EObject expectedNewValue,
 		EObject affectedEObject, EStructuralFeature affectedFeature, boolean wasUnset) {
+		assertCreateAndReplaceNonRoot(changes, expectedNewValue, affectedEObject, null, affectedFeature, wasUnset)
+	}
+	
+	def static Iterable<? extends EChange> assertCreateAndReplaceNonRoot(Iterable<? extends EChange> changes, EObject expectedNewValue,
+		EObject affectedEObject, EObject expectedOldValue, EStructuralFeature affectedFeature, boolean wasUnset) {
 		changes.assertSizeGreaterEquals(2)
 		return changes.assertCreateEObject(expectedNewValue)
-			.assertReplaceSingleValuedEReference(affectedEObject, affectedFeature, null, expectedNewValue, true, wasUnset, false)
+			.assertReplaceSingleValuedEReference(affectedEObject, affectedFeature, expectedOldValue, expectedNewValue, true, wasUnset, false)
 	}
 	
 	def static Iterable<? extends EChange> assertReplaceAndDeleteNonRoot(Iterable<? extends EChange> changes, EObject expectedOldValue,
 		EObject affectedEObject, EStructuralFeature affectedFeature, boolean isUnset) {
+		return changes
+			.assertReplaceSingleValuedEReference(affectedEObject, affectedFeature, expectedOldValue, null, true, false, isUnset)
+			.assertDeleteEObjectAndContainedElements(expectedOldValue)
+	}
+	
+	def static Iterable<? extends EChange> assertDeleteEObjectAndContainedElements(Iterable<? extends EChange> changes, EObject expectedOldValue) {
 		val deletedContainedElements = expectedOldValue.eAllContents.toList.reverse // elements are deleted from inner to outer
-		changes.assertSizeGreaterEquals(2 + deletedContainedElements.size)
-		var filteredChanges = changes.assertReplaceSingleValuedEReference(affectedEObject, affectedFeature, expectedOldValue, null, true, false, isUnset)
+		changes.assertSizeGreaterEquals(1 + deletedContainedElements.size)
+		var filteredChanges = changes
 		for (deletedContainedElement : deletedContainedElements) {
 			filteredChanges = filteredChanges.assertDeleteEObject(deletedContainedElement)
 		}
@@ -60,7 +56,7 @@ class CompoundEChangeAssertHelper {
 	def static Iterable<? extends EChange> assertRemoveAndDeleteRootEObject(Iterable<? extends EChange> changes, EObject expectedOldValue, String uri, Resource resource) {
 		changes.assertSizeGreaterEquals(2)
 		return changes.assertRemoveRootEObject(expectedOldValue, uri, resource)
-			.assertDeleteEObject(expectedOldValue)
+			.assertDeleteEObjectAndContainedElements(expectedOldValue)
 	}
 }
 		


### PR DESCRIPTION
This PR changes how delete changes are added to the change sequence recorded by the `ChangeRecorder`.
After recording finishes, the change recorder adds delete changes for every element implicitly deleted in the change sequence (i.e. for elements removed from their containment but not reinserted somewhere again). When inserting a delete change into the change sequence, any change after the delete change must not reference the deleted object anymore (as in theory the deleted object does not exist anymore at this point).

In the current behavior, the recorder adds the delete changes directly after the element is removed from its containment. However, this positioning does not guarantee that the element is never again referenced in changes after its delete change. As an example, a non-containment reference to the affected element might be unset after the element is removed from containment. While this would be easy to detect, since we also remove contained elements (see #48) such reference-after-delete issues might also occur more disguised when not the affected element itself but one of its descendants is referenced.

As such, this PR changes the behavior of the change recorder to append delete changes at the end of a change sequence. While identifying the earliest position in the sequence to insert the delete change would be possible, I opted for this easier solution simply as I didn't see any benefit of having the delete change as early as possible.
Additionally, this PR fixes the rare problem that an element and one of its descendants are both marked for deletion (when they are both removed from their containment), resulting in a duplicate delete change for the descendant (once from itself, once from its ancestor).