### PR TITLE
Use `Import-Package` instead of `Require-Bundle` for JUnit imports

### DIFF
--- a/bundles/tools.vitruv.testutils.metamodels/.classpath
+++ b/bundles/tools.vitruv.testutils.metamodels/.classpath
@@ -10,7 +10,6 @@
 			<attribute name="module" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/5"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="src" path="xtend-gen">

--- a/bundles/tools.vitruv.testutils.metamodels/META-INF/MANIFEST.MF
+++ b/bundles/tools.vitruv.testutils.metamodels/META-INF/MANIFEST.MF
@@ -31,11 +31,12 @@ Export-Package: allElementTypes,
  uml_mockup,
  uml_mockup.impl,
  uml_mockup.util
+Import-Package: org.junit.jupiter.api.extension,
+ org.junit.jupiter.params.converter,
+ org.junit.platform.commons
 Require-Bundle: edu.kit.ipd.sdq.activextendannotations,
  org.eclipse.xtend.lib,
  tools.vitruv.testutils,
- org.junit.jupiter.params,
- org.junit.jupiter.api,
  org.eclipse.core.runtime,
  org.eclipse.emf.ecore;visibility:=reexport
 Bundle-ActivationPolicy: lazy

--- a/bundles/tools.vitruv.testutils/.classpath
+++ b/bundles/tools.vitruv.testutils/.classpath
@@ -5,7 +5,6 @@
 			<attribute name="module" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/5"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="src" path="xtend-gen">

--- a/bundles/tools.vitruv.testutils/META-INF/MANIFEST.MF
+++ b/bundles/tools.vitruv.testutils/META-INF/MANIFEST.MF
@@ -5,14 +5,13 @@ Bundle-SymbolicName: tools.vitruv.testutils
 Automatic-Module-Name: tools.vitruv.testutils
 Bundle-Version: 3.0.1.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-17
+Import-Package: org.junit.jupiter.api.extension,
+ org.junit.jupiter.params.converter,
+ org.junit.platform.commons.support
 Require-Bundle: org.apache.log4j,
  org.slf4j.api,
  ch.qos.logback.classic,
  ch.qos.logback.core,
- org.junit,
- org.junit.jupiter.api,
- org.junit.jupiter.params,
- org.junit.platform.commons,
  org.hamcrest.core,
  org.eclipse.core.resources,
  org.eclipse.core.runtime,

--- a/tests/tools.vitruv.change.atomic.tests/.classpath
+++ b/tests/tools.vitruv.change.atomic.tests/.classpath
@@ -5,7 +5,6 @@
 			<attribute name="module" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/5"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="src" path="xtend-gen">

--- a/tests/tools.vitruv.change.atomic.tests/META-INF/MANIFEST.MF
+++ b/tests/tools.vitruv.change.atomic.tests/META-INF/MANIFEST.MF
@@ -7,8 +7,11 @@ Bundle-Version: 3.0.1.qualifier
 Bundle-Vendor: vitruv.tools
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Fragment-Host: tools.vitruv.change.atomic
+Import-Package: org.junit.jupiter.api,
+ org.junit.jupiter.api.extension,
+ org.junit.jupiter.api.function,
+ org.junit.jupiter.api.io
 Require-Bundle: org.eclipse.xtend.lib,
- org.junit.jupiter.api,
  org.hamcrest.core,
  tools.vitruv.testutils,
  tools.vitruv.testutils.metamodels

--- a/tests/tools.vitruv.change.composite.tests/.classpath
+++ b/tests/tools.vitruv.change.composite.tests/.classpath
@@ -5,7 +5,6 @@
 			<attribute name="module" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/5"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="src" path="xtend-gen">

--- a/tests/tools.vitruv.change.composite.tests/META-INF/MANIFEST.MF
+++ b/tests/tools.vitruv.change.composite.tests/META-INF/MANIFEST.MF
@@ -6,9 +6,12 @@ Automatic-Module-Name: tools.vitruv.change.composite.tests
 Bundle-Version: 3.0.1.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Fragment-Host: tools.vitruv.change.composite
-Require-Bundle: org.eclipse.xtend.lib,
- org.junit.jupiter.api,
+Import-Package: org.junit.jupiter.api,
+ org.junit.jupiter.api.extension,
+ org.junit.jupiter.api.function,
  org.junit.jupiter.params,
+ org.junit.jupiter.params.provider
+Require-Bundle: org.eclipse.xtend.lib,
  org.hamcrest.core,
  edu.kit.ipd.sdq.activextendannotations,
  tools.vitruv.testutils,

--- a/tests/tools.vitruv.change.correspondence.tests/.classpath
+++ b/tests/tools.vitruv.change.correspondence.tests/.classpath
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/5"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src">
 		<attributes>

--- a/tests/tools.vitruv.change.correspondence.tests/META-INF/MANIFEST.MF
+++ b/tests/tools.vitruv.change.correspondence.tests/META-INF/MANIFEST.MF
@@ -7,12 +7,13 @@ Bundle-Vendor: vitruv.tools
 Automatic-Module-Name: tools.vitruv.change.correspondence.tests
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Fragment-Host: tools.vitruv.change.correspondence
+Import-Package: org.junit.jupiter.api,
+ org.junit.jupiter.api.extension
 Require-Bundle: com.google.guava,
  org.eclipse.emf.ecore.xmi,
  org.eclipse.xtext.xbase.lib,
  org.eclipse.xtend.lib,
  org.eclipse.xtend.lib.macro,
- org.junit.jupiter.api,
  edu.kit.ipd.sdq.commons.util.java,
  tools.vitruv.testutils.metamodels,
  tools.vitruv.testutils

--- a/tests/tools.vitruv.testutils.tests/.classpath
+++ b/tests/tools.vitruv.testutils.tests/.classpath
@@ -5,7 +5,6 @@
 			<attribute name="module" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/5"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="src" path="xtend-gen"/>

--- a/tests/tools.vitruv.testutils.tests/META-INF/MANIFEST.MF
+++ b/tests/tools.vitruv.testutils.tests/META-INF/MANIFEST.MF
@@ -6,10 +6,13 @@ Bundle-Version: 3.0.1.qualifier
 Automatic-Module-Name: tools.vitruv.testutils.tests
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-Vendor: vitruv.tools
+Import-Package: org.junit.jupiter.api,
+ org.junit.jupiter.api.extension,
+ org.junit.jupiter.api.function,
+ org.junit.jupiter.params,
+ org.junit.jupiter.params.provider
 Require-Bundle: tools.vitruv.testutils,
  tools.vitruv.testutils.metamodels,
- org.junit.jupiter.api,
- org.junit.jupiter.params,
  org.hamcrest.core,
  com.google.guava,
  org.eclipse.xtend.lib


### PR DESCRIPTION
Since Eclipse 2022-09, the way how JUnit is bundled has changed. This resulted in Xtend tests failing which was resolved with #52. However, this fix introduced some incorrect dependency chain which resulted in Plug-In tests requiring several minutes to start. This PR refactors the JUnit imports from `Require-Bundle` which imports the bundle and all its packages and dependencies to `Import-Package` which allows more fine-grain control over imported packages. More details on when to use which can be found in [this discussion](https://stackoverflow.com/questions/1865819/when-should-i-use-import-package-and-when-should-i-use-require-bundle). As a consequence of the refactoring, JUnit can be removed from the classpath again.

We probably should iterate over all our dependencies and migrate them too where appropriate. For now, due to time constraints I only focused on JUnit as this will hopefully resolve the dependency chain issue and thus re-enable correct Plug-In tests execution.

Closes https://github.com/vitruv-tools/.github/issues/11

<details>
<summary>Dependency Chain Error Log</summary>

```
!ENTRY tools.vitruv.testutils.metamodels 4 0 2023-01-11 13:24:43.087
!MESSAGE FrameworkEvent ERROR
!STACK 0
org.osgi.framework.BundleException: Could not resolve module: tools.vitruv.testutils.metamodels [1025]
  Unresolved requirement: Require-Bundle: tools.vitruv.testutils
    -> Bundle-SymbolicName: tools.vitruv.testutils; bundle-version="3.0.1.202301090251"
       tools.vitruv.testutils [1023]
         No resolution report for the bundle.  Bundle was not resolved because of a uses constraint violation.
  org.apache.felix.resolver.reason.ReasonException: Uses constraint violation. Unable to resolve resource tools.vitruv.testutils [osgi.identity; osgi.identity="tools.vitruv.testutils"; type="osgi.bundle"; version:Version="3.0.1.202301090251"] because it is exposed to package 'org.junit.platform.commons.annotation' from resources org.junit.platform.commons [osgi.identity; osgi.identity="org.junit.platform.commons"; type="osgi.bundle"; version:Version="1.9.1.v20221103-2317"] and junit-platform-commons [osgi.identity; osgi.identity="junit-platform-commons"; type="osgi.bundle"; version:Version="1.9.1"] via two dependency chains.

Chain 1:
  tools.vitruv.testutils [osgi.identity; osgi.identity="tools.vitruv.testutils"; type="osgi.bundle"; version:Version="3.0.1.202301090251"]
    require: (osgi.wiring.bundle=org.junit.platform.commons)
     |
    provide: osgi.wiring.bundle: org.junit.platform.commons
  org.junit.platform.commons [osgi.identity; osgi.identity="org.junit.platform.commons"; type="osgi.bundle"; version:Version="1.9.1.v20221103-2317"]

Chain 2:
  tools.vitruv.testutils [osgi.identity; osgi.identity="tools.vitruv.testutils"; type="osgi.bundle"; version:Version="3.0.1.202301090251"]
    require: (osgi.wiring.bundle=org.junit.jupiter.api)
     |
    provide: osgi.wiring.bundle; bundle-version:Version="5.9.1.v20221103-2317"; osgi.wiring.bundle="org.junit.jupiter.api"
  org.junit.jupiter.api [osgi.identity; osgi.identity="org.junit.jupiter.api"; type="osgi.bundle"; version:Version="5.9.1.v20221103-2317"]
    import: (&(osgi.wiring.package=org.junit.jupiter.api.extension)(&(version>=5.9.0)(!(version>=6.0.0))))
     |
    export: osgi.wiring.package=org.junit.jupiter.api.extension; uses:=org.junit.platform.commons.annotation
  junit-jupiter-api [osgi.identity; osgi.identity="junit-jupiter-api"; type="osgi.bundle"; version:Version="5.9.1"]
    import: (&(osgi.wiring.package=org.junit.platform.commons.annotation)(&(version>=1.9.0)(!(version>=2.0.0))))
     |
    export: osgi.wiring.package: org.junit.platform.commons.annotation
  junit-platform-commons [osgi.identity; osgi.identity="junit-platform-commons"; type="osgi.bundle"; version:Version="1.9.1"]
	at org.eclipse.osgi.container.Module.start(Module.java:463)
	at org.eclipse.osgi.container.ModuleContainer$ContainerStartLevel$2.run(ModuleContainer.java:1852)
	at org.eclipse.osgi.internal.framework.EquinoxContainerAdaptor$1$1.execute(EquinoxContainerAdaptor.java:136)
	at org.eclipse.osgi.container.ModuleContainer$ContainerStartLevel.incStartLevel(ModuleContainer.java:1845)
	at org.eclipse.osgi.container.ModuleContainer$ContainerStartLevel.incStartLevel(ModuleContainer.java:1786)
	at org.eclipse.osgi.container.ModuleContainer$ContainerStartLevel.doContainerStartLevel(ModuleContainer.java:1750)
	at org.eclipse.osgi.container.ModuleContainer$ContainerStartLevel.dispatchEvent(ModuleContainer.java:1672)
	at org.eclipse.osgi.container.ModuleContainer$ContainerStartLevel.dispatchEvent(ModuleContainer.java:1)
	at org.eclipse.osgi.framework.eventmgr.EventManager.dispatchEvent(EventManager.java:234)
	at org.eclipse.osgi.framework.eventmgr.EventManager$EventThread.run(EventManager.java:345)
```
</details>