### PR TITLE
Add support for move operations in NotificationToEChangeConverter

### DIFF
--- a/bundles/tools.vitruv.change.composite/src/tools/vitruv/change/composite/recording/NotificationInfo.xtend
+++ b/bundles/tools.vitruv.change.composite/src/tools/vitruv/change/composite/recording/NotificationInfo.xtend
@@ -12,6 +12,18 @@ import org.eclipse.xtend.lib.annotations.Accessors
 import org.eclipse.xtend.lib.annotations.Delegate
 import org.eclipse.xtend.lib.annotations.FinalFieldsConstructor
 
+package enum EventType {
+	ADD,
+	ADD_MANY,
+	MOVE,
+	REMOVE,
+	REMOVE_MANY,
+	REMOVING_ADAPTER,
+	RESOLVE,
+	SET,
+	UNSET
+}
+
 /** 
  * NotificationInfo is a type safe wrapper for EMF Notifications. It wraps a {@link Notification}and implements a few 
  * additional getter methods
@@ -22,6 +34,25 @@ package class NotificationInfo implements Notification {
 	val Notification notification
 	@Accessors
 	var String validationMessage
+	
+	override int getEventType() {
+		throw new IllegalArgumentException("Use eventTypeEnum for type-safe event types.")
+	}
+	
+	def EventType getEventTypeEnum() {
+		switch(notification.eventType) {
+			case SET: EventType.SET
+			case UNSET: EventType.UNSET
+			case ADD: EventType.ADD
+			case REMOVE: EventType.REMOVE
+			case ADD_MANY: EventType.ADD_MANY
+			case REMOVE_MANY: EventType.REMOVE_MANY
+			case MOVE: EventType.MOVE
+			case REMOVING_ADAPTER: EventType.REMOVING_ADAPTER
+			case RESOLVE: EventType.RESOLVE
+			default: throw new IllegalArgumentException("Unexpected eventType.")
+		}
+	}
 
 	/** 
 	 * @return the structural feature affected

--- a/bundles/tools.vitruv.change.composite/src/tools/vitruv/change/composite/recording/NotificationInfo.xtend
+++ b/bundles/tools.vitruv.change.composite/src/tools/vitruv/change/composite/recording/NotificationInfo.xtend
@@ -12,6 +12,11 @@ import org.eclipse.xtend.lib.annotations.Accessors
 import org.eclipse.xtend.lib.annotations.Delegate
 import org.eclipse.xtend.lib.annotations.FinalFieldsConstructor
 
+/*
+ * note:
+ * - event type CREATE is deprecated and not added to EventYpe enum
+ * - fields NO_FEATURE_ID, NO_INDEX and EVENT_TYPE_COUNT are no event types
+ */
 package enum EventType {
 	ADD,
 	ADD_MANY,

--- a/bundles/tools.vitruv.change.composite/src/tools/vitruv/change/composite/recording/NotificationToEChangeConverter.xtend
+++ b/bundles/tools.vitruv.change.composite/src/tools/vitruv/change/composite/recording/NotificationToEChangeConverter.xtend
@@ -13,8 +13,6 @@ import tools.vitruv.change.atomic.eobject.EObjectAddedEChange
 import tools.vitruv.change.atomic.feature.attribute.AttributeFactory
 import tools.vitruv.change.atomic.feature.reference.UpdateReferenceEChange
 
-import static org.eclipse.emf.common.notify.Notification.*
-
 import static extension edu.kit.ipd.sdq.commons.util.java.lang.IterableUtil.*
 import static extension tools.vitruv.change.composite.recording.EChangeCreationUtil.*
 
@@ -44,39 +42,50 @@ package final class NotificationToEChangeConverter {
 			case oldValue == newValue:
 				emptyList()
 			case notification.isAttributeNotification:
-				switch (eventType) {
+				switch (eventTypeEnum) {
 					case SET: handleSetAttribute(notification)
 					case UNSET: handleUnsetAttribute(notification)
 					case ADD: handleInsertAttribute(notification)
 					case ADD_MANY: handleMultiInsertAttribute(notification)
 					case REMOVE: handleRemoveAttribute(notification)
 					case REMOVE_MANY: handleMultiRemoveAttribute(notification)
-					default: emptyList()
+					case MOVE: handleMoveAttribute(notification)
+					case RESOLVE: throw new IllegalArgumentException("Event type RESOLVE for Attribute Notifications unexpected.")
+					case REMOVING_ADAPTER: throw new IllegalArgumentException("Event type REMOVING_ADAPTER for Attribute Notifications unexpected.")
+					default: throw new IllegalArgumentException("Unexpected event type " + eventType)
 				}
 			case notification.isReferenceNotification:
-				switch (eventType) {
+				switch (eventTypeEnum) {
 					case SET: handleSetReference(notification)
 					case UNSET: handleUnsetReference(notification)
 					case ADD: handleInsertReference(notification)
 					case ADD_MANY: handleMultiInsertReference(notification)
 					case REMOVE: handleRemoveReference(notification)
 					case REMOVE_MANY: handleMultiRemoveReference(notification)
-					default: emptyList()
+					case MOVE: handleMoveReference(notification)
+					case RESOLVE: throw new IllegalArgumentException("Event type RESOLVE for Reference Notifications unexpected.")
+					case REMOVING_ADAPTER: throw new IllegalArgumentException("Event type REMOVING_ADAPTER for Reference Notifications unexpected.")
+					default: throw new IllegalArgumentException("Unexpected event type " + eventType)
 				}
 			case notifier instanceof Resource:
 				switch (getFeatureID(Resource)) {
 					case Resource.RESOURCE__CONTENTS:
-						switch (eventType) {
+						switch (eventTypeEnum) {
 							case ADD: handleInsertRootChange(notification)
 							case ADD_MANY: handleMultiInsertRootChange(notification)
 							case REMOVE: handleRemoveRootChange(notification)
 							case REMOVE_MANY: handleMultiRemoveRootChange(notification)
-							default: emptyList()
+							case SET: throw new IllegalArgumentException("Event type SET for Resource Content Notifications unexpected.")
+							case UNSET: throw new IllegalArgumentException("Event type UNSET for Resource Content Notifications unexpected.")
+							case MOVE: throw new IllegalArgumentException("Event type MOVE for Resource Content Notifications unexpected.")
+							case RESOLVE: throw new IllegalArgumentException("Event type RESOLVE for Resource Content Notifications unexpected.")
+							case REMOVING_ADAPTER: throw new IllegalArgumentException("Event type REMOVING_ADAPTER for Resource Content Notifications unexpected.")
+							default: throw new IllegalArgumentException("Unexpected event type " + eventType)
 						}
 					case Resource.RESOURCE__URI:
-						switch (eventType) {
+						switch (eventTypeEnum) {
 							case SET: handleSetUriChange(notification)
-							default: emptyList()
+							default: throw new IllegalArgumentException("Unexpected event type " + eventType + " for Resource URI Notification.")
 						}
 					default:
 						emptyList()
@@ -84,6 +93,20 @@ package final class NotificationToEChangeConverter {
 			default:
 				emptyList()
 		}
+	}
+	
+	private def Iterable<? extends EChange> handleMoveAttribute(extension NotificationInfo notification) {
+		#[
+			createRemoveAttributeChange(notifierModelElement, attribute, oldValue as Integer, newValue),
+			createInsertAttributeChange(notifierModelElement, attribute, position, newValue)
+		]
+	}
+	
+	private def Iterable<? extends EChange> handleMoveReference(extension NotificationInfo notification) {
+		#[
+			createRemoveReferenceChange(notifierModelElement, reference, newModelElementValue, oldValue as Integer),
+			createInsertReferenceChange(notifierModelElement, reference, newModelElementValue, position)
+		]
 	}
 
 	def private Iterable<? extends EChange> handleSetAttribute(extension NotificationInfo notification) {

--- a/bundles/tools.vitruv.change.composite/src/tools/vitruv/change/composite/recording/NotificationToEChangeConverter.xtend
+++ b/bundles/tools.vitruv.change.composite/src/tools/vitruv/change/composite/recording/NotificationToEChangeConverter.xtend
@@ -30,6 +30,13 @@ package final class NotificationToEChangeConverter {
 		return createDeleteEObjectChange(eObject)
 	}
 	
+	private def String convertExceptionMessage(EventType eventType, String notificationType) {
+		String.format("Event type {} for {} Notifications unexpected.")
+	}
+	final String ATTRIBUTE_TYPE = "Attribute";
+	final String REFERENCE_TYPE = "Reference";
+	final String RESOURCE_CONTENTS_TYPE = "Resource Contents"
+	
 	/** 
 	 * Converts the given notification to a list of {@link EChange}s.
 	 * @param n the notification to convert
@@ -50,8 +57,8 @@ package final class NotificationToEChangeConverter {
 					case REMOVE: handleRemoveAttribute(notification)
 					case REMOVE_MANY: handleMultiRemoveAttribute(notification)
 					case MOVE: handleMoveAttribute(notification)
-					case RESOLVE: throw new IllegalArgumentException("Event type RESOLVE for Attribute Notifications unexpected.")
-					case REMOVING_ADAPTER: throw new IllegalArgumentException("Event type REMOVING_ADAPTER for Attribute Notifications unexpected.")
+					case RESOLVE: throw new IllegalArgumentException(convertExceptionMessage(EventType.RESOLVE, ATTRIBUTE_TYPE))
+					case REMOVING_ADAPTER: throw new IllegalArgumentException(convertExceptionMessage(EventType.REMOVING_ADAPTER, ATTRIBUTE_TYPE))
 					default: throw new IllegalArgumentException("Unexpected event type " + eventType)
 				}
 			case notification.isReferenceNotification:
@@ -63,8 +70,8 @@ package final class NotificationToEChangeConverter {
 					case REMOVE: handleRemoveReference(notification)
 					case REMOVE_MANY: handleMultiRemoveReference(notification)
 					case MOVE: handleMoveReference(notification)
-					case RESOLVE: throw new IllegalArgumentException("Event type RESOLVE for Reference Notifications unexpected.")
-					case REMOVING_ADAPTER: throw new IllegalArgumentException("Event type REMOVING_ADAPTER for Reference Notifications unexpected.")
+					case RESOLVE: throw new IllegalArgumentException(convertExceptionMessage(EventType.RESOLVE, REFERENCE_TYPE))
+					case REMOVING_ADAPTER: throw new IllegalArgumentException(convertExceptionMessage(EventType.REMOVING_ADAPTER, REFERENCE_TYPE))
 					default: throw new IllegalArgumentException("Unexpected event type " + eventType)
 				}
 			case notifier instanceof Resource:
@@ -75,11 +82,11 @@ package final class NotificationToEChangeConverter {
 							case ADD_MANY: handleMultiInsertRootChange(notification)
 							case REMOVE: handleRemoveRootChange(notification)
 							case REMOVE_MANY: handleMultiRemoveRootChange(notification)
-							case SET: throw new IllegalArgumentException("Event type SET for Resource Content Notifications unexpected.")
-							case UNSET: throw new IllegalArgumentException("Event type UNSET for Resource Content Notifications unexpected.")
-							case MOVE: throw new IllegalArgumentException("Event type MOVE for Resource Content Notifications unexpected.")
-							case RESOLVE: throw new IllegalArgumentException("Event type RESOLVE for Resource Content Notifications unexpected.")
-							case REMOVING_ADAPTER: throw new IllegalArgumentException("Event type REMOVING_ADAPTER for Resource Content Notifications unexpected.")
+							case SET: throw new IllegalArgumentException(convertExceptionMessage(EventType.SET, RESOURCE_CONTENTS_TYPE))
+							case UNSET: throw new IllegalArgumentException(convertExceptionMessage(EventType.UNSET, RESOURCE_CONTENTS_TYPE))
+							case MOVE: throw new IllegalArgumentException(convertExceptionMessage(EventType.MOVE, RESOURCE_CONTENTS_TYPE))
+							case RESOLVE: throw new IllegalArgumentException(convertExceptionMessage(EventType.RESOLVE, RESOURCE_CONTENTS_TYPE))
+							case REMOVING_ADAPTER: throw new IllegalArgumentException(convertExceptionMessage(EventType.REMOVING_ADAPTER, RESOURCE_CONTENTS_TYPE))
 							default: throw new IllegalArgumentException("Unexpected event type " + eventType)
 						}
 					case Resource.RESOURCE__URI:

--- a/tests/tools.vitruv.change.composite.tests/src/tools/vitruv/change/composite/attribute/ChangeDescription2MoveEAttributeTest.xtend
+++ b/tests/tools.vitruv.change.composite.tests/src/tools/vitruv/change/composite/attribute/ChangeDescription2MoveEAttributeTest.xtend
@@ -1,0 +1,74 @@
+package tools.vitruv.change.composite.attribute
+
+import tools.vitruv.change.composite.ChangeDescription2ChangeTransformationTest
+import org.junit.jupiter.api.Test
+import static allElementTypes.AllElementTypesPackage.Literals.*
+import static extension tools.vitruv.change.composite.util.AtomicEChangeAssertHelper.assertRemoveEAttribute
+import static extension tools.vitruv.change.composite.util.AtomicEChangeAssertHelper.assertInsertEAttribute
+import static extension tools.vitruv.change.composite.util.AtomicEChangeAssertHelper.assertEmpty
+
+class ChangeDescription2MoveEAttributeTest extends ChangeDescription2ChangeTransformationTest {
+	
+	@Test
+	def void moveMultiValuedEAttribute() {
+		// prepare
+		uniquePersistedRoot => [
+			multiValuedEAttribute += 42
+			multiValuedEAttribute += 55
+			multiValuedEAttribute += 66
+		]
+		
+		// test
+		val result = uniquePersistedRoot.record [
+			multiValuedEAttribute.move(0, 1)
+		]
+		
+		// assert
+		result.assertChangeCount(2)
+			.assertRemoveEAttribute(uniquePersistedRoot, ROOT__MULTI_VALUED_EATTRIBUTE, 55, 1)
+			.assertInsertEAttribute(uniquePersistedRoot, ROOT__MULTI_VALUED_EATTRIBUTE, 55, 0, false)
+			.assertEmpty
+	}
+	
+	@Test
+	def void moveMultiValuedUnsettableEAttribute() {
+		// prepare
+		uniquePersistedRoot => [
+			multiValuedUnsettableEAttribute += 42
+			multiValuedUnsettableEAttribute += 55
+			multiValuedUnsettableEAttribute += 66
+		]
+		
+		// test
+		val result = uniquePersistedRoot.record [
+			multiValuedUnsettableEAttribute.move(0, 1)
+		]
+		
+		// assert
+		result.assertChangeCount(2)
+			.assertRemoveEAttribute(uniquePersistedRoot, ROOT__MULTI_VALUED_UNSETTABLE_EATTRIBUTE, 55, 1)
+			.assertInsertEAttribute(uniquePersistedRoot, ROOT__MULTI_VALUED_UNSETTABLE_EATTRIBUTE, 55, 0, false)
+			.assertEmpty
+	}
+	
+	@Test
+	def void moveMultiValuedUnorderedEAttribute() {
+		// prepare
+		uniquePersistedRoot => [
+			multiValuedUnorderedEAttribute += 42
+			multiValuedUnorderedEAttribute += 55
+			multiValuedUnorderedEAttribute += 66
+		]
+		
+		// test
+		val result = uniquePersistedRoot.record [
+			multiValuedUnorderedEAttribute.move(0, 1)
+		]
+		
+		// assert
+		result.assertChangeCount(2)
+			.assertRemoveEAttribute(uniquePersistedRoot, ROOT__MULTI_VALUED_UNORDERED_EATTRIBUTE, 55, 1)
+			.assertInsertEAttribute(uniquePersistedRoot, ROOT__MULTI_VALUED_UNORDERED_EATTRIBUTE, 55, 0, false)
+			.assertEmpty
+	}
+}

--- a/tests/tools.vitruv.change.composite.tests/src/tools/vitruv/change/composite/reference/ChangeDescription2MoveERefenceTest.xtend
+++ b/tests/tools.vitruv.change.composite.tests/src/tools/vitruv/change/composite/reference/ChangeDescription2MoveERefenceTest.xtend
@@ -1,0 +1,170 @@
+package tools.vitruv.change.composite.reference
+
+import tools.vitruv.change.composite.ChangeDescription2ChangeTransformationTest
+import org.junit.jupiter.api.Test
+import static tools.vitruv.testutils.metamodels.AllElementTypesCreators.*
+import static extension tools.vitruv.change.composite.util.AtomicEChangeAssertHelper.*
+import static allElementTypes.AllElementTypesPackage.Literals.*
+
+
+class ChangeDescription2MoveERefenceTest extends ChangeDescription2ChangeTransformationTest {
+	
+	@Test
+	def void moveMultiValuedNonContainmentEReference() {
+		// prepare
+		val nonRoot1 = aet.NonRoot
+		val nonRoot2 = aet.NonRoot
+		val nonRoot3 = aet.NonRoot
+		uniquePersistedRoot => [
+			multiValuedContainmentEReference += nonRoot1
+			multiValuedContainmentEReference += nonRoot2
+			multiValuedContainmentEReference += nonRoot3
+		]
+		uniquePersistedRoot => [
+			multiValuedNonContainmentEReference += nonRoot1
+			multiValuedNonContainmentEReference += nonRoot2
+			multiValuedNonContainmentEReference += nonRoot3
+		]
+		
+		// test
+		val result = uniquePersistedRoot.record [
+			multiValuedNonContainmentEReference.move(0, 1)
+		]
+		
+		// assert
+		result.assertChangeCount(2)
+			.assertRemoveEReference(uniquePersistedRoot, ROOT__MULTI_VALUED_NON_CONTAINMENT_EREFERENCE, nonRoot2, 1, false)
+			.assertInsertEReference(uniquePersistedRoot, ROOT__MULTI_VALUED_NON_CONTAINMENT_EREFERENCE, nonRoot2, 0, false, false)
+			.assertEmpty
+	}
+	
+	@Test
+	def void moveMultiValuedUnsettableNonContainmentEReference() {
+		// prepare
+		val nonRoot1 = aet.NonRoot
+		val nonRoot2 = aet.NonRoot
+		val nonRoot3 = aet.NonRoot
+		uniquePersistedRoot => [
+			multiValuedContainmentEReference += nonRoot1
+			multiValuedContainmentEReference += nonRoot2
+			multiValuedContainmentEReference += nonRoot3
+		]
+		uniquePersistedRoot => [
+			multiValuedUnsettableNonContainmentEReference += nonRoot1
+			multiValuedUnsettableNonContainmentEReference += nonRoot2
+			multiValuedUnsettableNonContainmentEReference += nonRoot3
+		]
+		
+		// test
+		val result = uniquePersistedRoot.record [
+			multiValuedUnsettableNonContainmentEReference.move(0, 1)
+		]
+		
+		// assert
+		result.assertChangeCount(2)
+			.assertRemoveEReference(uniquePersistedRoot, ROOT__MULTI_VALUED_UNSETTABLE_NON_CONTAINMENT_EREFERENCE, nonRoot2, 1, false)
+			.assertInsertEReference(uniquePersistedRoot, ROOT__MULTI_VALUED_UNSETTABLE_NON_CONTAINMENT_EREFERENCE, nonRoot2, 0, false, false)
+			.assertEmpty
+	}
+	
+	@Test
+	def void moveMultiValuedUnorderedNonContainmentEReference() {
+		// prepare
+		val nonRoot1 = aet.NonRoot
+		val nonRoot2 = aet.NonRoot
+		val nonRoot3 = aet.NonRoot
+		uniquePersistedRoot => [
+			multiValuedContainmentEReference += nonRoot1
+			multiValuedContainmentEReference += nonRoot2
+			multiValuedContainmentEReference += nonRoot3
+		]
+		uniquePersistedRoot => [
+			multiValuedUnorderedNonContainmentEReference += nonRoot1
+			multiValuedUnorderedNonContainmentEReference += nonRoot2
+			multiValuedUnorderedNonContainmentEReference += nonRoot3
+		]
+		
+		// test
+		val result = uniquePersistedRoot.record [
+			multiValuedUnorderedNonContainmentEReference.move(0, 1)
+		]
+		
+		// assert
+		result.assertChangeCount(2)
+			.assertRemoveEReference(uniquePersistedRoot, ROOT__MULTI_VALUED_UNORDERED_NON_CONTAINMENT_EREFERENCE, nonRoot2, 1, false)
+			.assertInsertEReference(uniquePersistedRoot, ROOT__MULTI_VALUED_UNORDERED_NON_CONTAINMENT_EREFERENCE, nonRoot2, 0, false, false)
+			.assertEmpty
+	}
+	
+	@Test
+	def void moveMultiValuedContainmentEReference() {
+		// prepare
+		val nonRoot1 = aet.NonRoot
+		val nonRoot2 = aet.NonRoot
+		val nonRoot3 = aet.NonRoot
+		uniquePersistedRoot => [
+			multiValuedContainmentEReference += nonRoot1
+			multiValuedContainmentEReference += nonRoot2
+			multiValuedContainmentEReference += nonRoot3
+		]
+		
+		// test
+		val result = uniquePersistedRoot.record [
+			multiValuedContainmentEReference.move(0, 1)
+		]
+		
+		// assert
+		result.assertChangeCount(2)
+			.assertRemoveEReference(uniquePersistedRoot, ROOT__MULTI_VALUED_CONTAINMENT_EREFERENCE, nonRoot2, 1, true)
+			.assertInsertEReference(uniquePersistedRoot, ROOT__MULTI_VALUED_CONTAINMENT_EREFERENCE, nonRoot2, 0, true, false)
+			.assertEmpty
+	}
+	
+	@Test
+	def void moveMultiValuedUnsettableContainmentEReference() {
+		// prepare
+		val nonRoot1 = aet.NonRoot
+		val nonRoot2 = aet.NonRoot
+		val nonRoot3 = aet.NonRoot
+		uniquePersistedRoot => [
+			multiValuedUnsettableContainmentEReference += nonRoot1
+			multiValuedUnsettableContainmentEReference += nonRoot2
+			multiValuedUnsettableContainmentEReference += nonRoot3
+		]
+		
+		// test
+		val result = uniquePersistedRoot.record [
+			multiValuedUnsettableContainmentEReference.move(0, 1)
+		]
+		
+		// assert
+		result.assertChangeCount(2)
+			.assertRemoveEReference(uniquePersistedRoot, ROOT__MULTI_VALUED_UNSETTABLE_CONTAINMENT_EREFERENCE, nonRoot2, 1, true)
+			.assertInsertEReference(uniquePersistedRoot, ROOT__MULTI_VALUED_UNSETTABLE_CONTAINMENT_EREFERENCE, nonRoot2, 0, true, false)
+			.assertEmpty
+	}
+	
+	@Test
+	def void moveMultiValuedUnorderedContainmentEReference() {
+		// prepare
+		val nonRoot1 = aet.NonRoot
+		val nonRoot2 = aet.NonRoot
+		val nonRoot3 = aet.NonRoot
+		uniquePersistedRoot => [
+			multiValuedUnorderedContainmentEReference += nonRoot1
+			multiValuedUnorderedContainmentEReference += nonRoot2
+			multiValuedUnorderedContainmentEReference += nonRoot3
+		]
+		
+		// test
+		val result = uniquePersistedRoot.record [
+			multiValuedUnorderedContainmentEReference.move(0, 1)
+		]
+		
+		// assert
+		result.assertChangeCount(2)
+			.assertRemoveEReference(uniquePersistedRoot, ROOT__MULTI_VALUED_UNORDERED_CONTAINMENT_EREFERENCE, nonRoot2, 1, true)
+			.assertInsertEReference(uniquePersistedRoot, ROOT__MULTI_VALUED_UNORDERED_CONTAINMENT_EREFERENCE, nonRoot2, 0, true, false)
+			.assertEmpty
+	}
+}


### PR DESCRIPTION
- add handling of moving attributes and references
- add tests
- add type safe implementation for EventType in NotificationInfo & throw exceptions on unexpected event types in NotificationToEChangeConverter

----------------------------
- for issue #56 