### PR TITLE
Fix usage of ResourceSet in DefaultStateBasedChangeResolutionStrategy & DeltaBasedResource

### DIFF
--- a/bundles/tools.vitruv.change.changederivation/src/tools/vitruv/change/changederivation/DefaultStateBasedChangeResolutionStrategy.xtend
+++ b/bundles/tools.vitruv.change.changederivation/src/tools/vitruv/change/changederivation/DefaultStateBasedChangeResolutionStrategy.xtend
@@ -1,5 +1,6 @@
 package tools.vitruv.change.changederivation
 
+import edu.kit.ipd.sdq.commons.util.org.eclipse.emf.ecore.resource.ResourceCopier
 import org.eclipse.emf.common.notify.Notifier
 import org.eclipse.emf.common.util.BasicMonitor
 import org.eclipse.emf.compare.EMFCompare
@@ -19,11 +20,11 @@ import tools.vitruv.change.composite.description.VitruviusChange
 import tools.vitruv.change.composite.recording.ChangeRecorder
 
 import static com.google.common.base.Preconditions.checkArgument
+import static edu.kit.ipd.sdq.commons.util.org.eclipse.emf.ecore.resource.ResourceSetUtil.withGlobalFactories
 
 import static extension edu.kit.ipd.sdq.commons.util.org.eclipse.emf.ecore.resource.ResourceUtil.getReferencedProxies
 import static extension tools.vitruv.change.atomic.resolve.EChangeIdResolverAndApplicator.applyBackward
 import static extension tools.vitruv.change.atomic.resolve.EChangeIdResolverAndApplicator.applyForward
-import edu.kit.ipd.sdq.commons.util.org.eclipse.emf.ecore.resource.ResourceCopier
 
 /**
  * This default strategy for diff based state changes uses EMFCompare to resolve a 
@@ -74,7 +75,7 @@ class DefaultStateBasedChangeResolutionStrategy implements StateBasedChangeResol
         newState.checkNoProxies("new state")
         // It is possible that root elements are automatically generated during resource creation (e.g., Java packages).
         // Thus, we create the resource and then monitor the re-insertion of the elements
-        val monitoredResourceSet = new ResourceSetImpl()
+        val monitoredResourceSet = withGlobalFactories(new ResourceSetImpl());
         val newResource = monitoredResourceSet.createResource(newState.URI)
         newResource.contents.clear()
         return newResource.record [

--- a/bundles/tools.vitruv.change.changederivation/src/tools/vitruv/change/changederivation/DeltaBasedResource.xtend
+++ b/bundles/tools.vitruv.change.changederivation/src/tools/vitruv/change/changederivation/DeltaBasedResource.xtend
@@ -12,6 +12,7 @@ import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl
 import tools.vitruv.change.atomic.EChange
 import tools.vitruv.change.atomic.id.IdResolver
 import tools.vitruv.change.composite.description.VitruviusChangeFactory
+import static edu.kit.ipd.sdq.commons.util.org.eclipse.emf.ecore.resource.ResourceSetUtil.withGlobalFactories
 
 class DeltaBasedResource extends ResourceImpl {
 	
@@ -20,7 +21,7 @@ class DeltaBasedResource extends ResourceImpl {
 	}
 	
 	private static def List<EChange> loadDeltas(URI modelUri) {
-        val resourceSet = new ResourceSetImpl();
+        val resourceSet = withGlobalFactories(new ResourceSetImpl());
         val resource = resourceSet.getResource(modelUri, true);
         return resource.getContents().map[it as EChange].toList
 	}
@@ -32,8 +33,8 @@ class DeltaBasedResource extends ResourceImpl {
 	
 	override doSave(OutputStream outputStream, Map<?, ?> options) throws IOException {
 		val deltaChanges = new DefaultStateBasedChangeResolutionStrategy().getChangeSequenceForCreated(this).EChanges;
-		val resSet = new ResourceSetImpl();
-		val resource = resSet.createResource(this.URI);
+		val resourceSet = withGlobalFactories(new ResourceSetImpl());
+		val resource = resourceSet.createResource(this.URI);
 		resource.getContents().addAll(deltaChanges)
 		try (val out = outputStream){
 			resource.save(out, Collections.EMPTY_MAP)


### PR DESCRIPTION
Instantiate ResourceSet with global factories in DefaultStateBasedChangeResolutionStrategy and DeltaBasedResource.

To fix build/tests of https://github.com/vitruv-tools/Vitruv/pull/585