### PR TITLE
Changes required for Vitruv-Remote

### DIFF
--- a/bundles/tools.vitruv.change.atomic/src/tools/vitruv/change/atomic/hid/HierarchicalId.java
+++ b/bundles/tools.vitruv.change.atomic/src/tools/vitruv/change/atomic/hid/HierarchicalId.java
@@ -1,12 +1,14 @@
 package tools.vitruv.change.atomic.hid;
 
+import org.eclipse.emf.ecore.impl.EObjectImpl;
+
 /**
  * A hierarchical id is a volatile identifier which identifies an element based
  * on its hierarchical location in a resource. A hierarchical id is not bound to
  * a resource set, i.e. two elements at the same location in identical resources
  * of different resource sets will have the same hierarchical id.
  */
-public final class HierarchicalId implements Comparable<HierarchicalId> {
+public final class HierarchicalId extends EObjectImpl implements Comparable<HierarchicalId> {
 	private String id;
 
 	public HierarchicalId(String id) {

--- a/bundles/tools.vitruv.change.composite/src/tools/vitruv/change/composite/description/impl/AbstractVitruviusChangeResolver.java
+++ b/bundles/tools.vitruv.change.composite/src/tools/vitruv/change/composite/description/impl/AbstractVitruviusChangeResolver.java
@@ -37,6 +37,7 @@ abstract class AbstractVitruviusChangeResolver<Id> implements VitruviusChangeRes
 			List<EChange<Target>> resolvedChanges = transactionalChange.getEChanges().stream().map(changeHandler::apply)
 					.toList();
 			TransactionalChange<Target> result = new TransactionalChangeImpl<>(resolvedChanges);
+			result.setUserInteractions(change.getUserInteractions());
 			onTransactionEnd.accept(result);
 			return result;
 		}


### PR DESCRIPTION
Contains changes required for Vitruv-Remote:

- `HierarichalId` extends from `EObject`, so it can be serialized (Jackson Serializer expects objects to be part of a model and therefore expect EObjects)
- in the `transformVitruviusChange()` method, also copy user interactions to the transformed change, because client sends user interactions with a change