### PR TITLE
Fix for Issue #71

### DIFF
--- a/tests/tools.vitruv.change.composite.tests/src/tools/vitruv/change/composite/recording/ChangeRecorderTest.xtend
+++ b/tests/tools.vitruv.change.composite.tests/src/tools/vitruv/change/composite/recording/ChangeRecorderTest.xtend
@@ -194,7 +194,9 @@ class ChangeRecorderTest {
 			resource.contents.clear()
 		]
 
-		assertThat(changeRecorder.change, hasEChanges(RemoveRootEObject, DeleteEObject, DeleteEObject, DeleteEObject, DeleteEObject))
+		assertThat(changeRecorder.change, hasEChanges(
+			RemoveRootEObject, RemoveEReference, DeleteEObject, RemoveEReference, DeleteEObject, ReplaceSingleValuedEReference, DeleteEObject, DeleteEObject
+		))
 	}
 
 	@DisplayName("adds an object set as containment to the recording")
@@ -370,7 +372,7 @@ class ChangeRecorderTest {
 		record [
 			resource.delete(emptyMap)
 		]
-		assertThat(changeRecorder.change, hasEChanges(RemoveRootEObject, DeleteEObject, DeleteEObject))
+		assertThat(changeRecorder.change, hasEChanges(RemoveRootEObject, ReplaceSingleValuedEReference, DeleteEObject, DeleteEObject))
 	}
 
 	@ParameterizedTest(name="while isRecording={0}")

--- a/tests/tools.vitruv.change.composite.tests/src/tools/vitruv/change/composite/reference/ChangeDescription2RemoveEReferenceTest.xtend
+++ b/tests/tools.vitruv.change.composite.tests/src/tools/vitruv/change/composite/reference/ChangeDescription2RemoveEReferenceTest.xtend
@@ -145,10 +145,11 @@ class ChangeDescription2RemoveEReferenceTest extends ChangeDescription2ChangeTra
 		]
 
 		// assert
-		result.assertChangeCount(5)
+		result.assertChangeCount(6)
 			.assertReplaceSingleValuedEReference(uniquePersistedRoot, ROOT__RECURSIVE_ROOT, containedRoot, null, true, false, false)
 			.assertReplaceSingleValuedEReference(innerContainedRoot, ROOT__SINGLE_VALUED_CONTAINMENT_EREFERENCE, nonRoot, null, true, false, false)
 			.assertReplaceSingleValuedEReference(uniquePersistedRoot, ROOT__SINGLE_VALUED_CONTAINMENT_EREFERENCE, null, nonRoot, true, false, false)
+			.assertReplaceSingleValuedEReference(containedRoot, ROOT__RECURSIVE_ROOT, innerContainedRoot, null, true, false, false)
 			.assertDeleteEObjectAndContainedElements(containedRoot)
 			.assertEmpty
 	}


### PR DESCRIPTION
createDeleteChanges (formerly createDeleteChange) creates, for each deleted object that has a container, a

1. RemoveReferenceChange, if this containment relationship is many(=multi)-valued,
2. ReplaceSingleReferenceChange, if the containment only allows one contained object at at time.