### PR TITLE
Split CI workflow jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,12 +44,10 @@ jobs:
     - name: Verify build with Sonar
       if: matrix.os == 'ubuntu-latest'
       run: >
-        ./mvnw clean verify javadoc:javadoc-no-fork sonar:sonar -P coverage
+        ./mvnw clean verify
         --batch-mode
         --update-snapshots
         --no-transfer-progress
-      env:
-        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
     - name: Stage build results
       run: mkdir staging-${{ matrix.os }} && cp **/target/*.jar staging-${{ matrix.os }}/
@@ -59,6 +57,61 @@ jobs:
       with:
         name: Build Results
         path: staging-*/
+
+  verify-javadoc:
+    name: Verify JavaDoc
+    runs-on: ubuntu-latest
+    needs: [verify]
+    strategy:
+      fail-fast: true
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4.2.2
+
+    - name: Setup Java and Maven cache
+      uses: actions/setup-java@v4.5.0
+      with:
+        distribution: 'temurin'
+        java-version: '17'
+        check-latest: true
+        cache: 'maven'
+
+    - name: Verify JavaDoc
+      run: >
+        ./mvnw clean javadoc:javadoc
+        -DskipTests
+        --batch-mode
+        --update-snapshots
+        --no-transfer-progress
+
+  sonar:
+    name: SonarQube analysis
+    runs-on: ubuntu-latest
+    needs: [verify]
+    strategy:
+      fail-fast: true
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4.2.2
+
+    - name: Setup Java and Maven cache
+      uses: actions/setup-java@v4.5.0
+      with:
+        distribution: 'temurin'
+        java-version: '17'
+        check-latest: true
+        cache: 'maven'
+
+    - name: Run SonarQube analysis
+      run: >
+        ./mvnw clean verify sonar:sonar -P coverage
+        --batch-mode
+        --update-snapshots
+        --no-transfer-progress
+      env:
+        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
   deploy-snapshot:
     name: Deploy snapshot

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
 
     - name: Verify JavaDoc
       run: >
-        ./mvnw clean javadoc:javadoc
+        ./mvnw clean compile javadoc:javadoc
         -DskipTests
         --batch-mode
         --update-snapshots


### PR DESCRIPTION
reason: makes it easier to see where the problem is when a build fails