### PR TITLE
Disable JavaDoc and SonarQube analysis for dependabot PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,6 @@ jobs:
     name: Verify JavaDoc
     runs-on: ubuntu-latest
     needs: [verify]
-    if: github.actor != 'dependabot[bot]'
     strategy:
       fail-fast: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,7 @@ jobs:
     name: Verify JavaDoc
     runs-on: ubuntu-latest
     needs: [verify]
+    if: github.actor != 'dependabot[bot]'
     strategy:
       fail-fast: true
 
@@ -85,6 +86,7 @@ jobs:
     name: SonarQube analysis
     runs-on: ubuntu-latest
     needs: [verify]
+    if: github.actor != 'dependabot[bot]'
     strategy:
       fail-fast: true
 


### PR DESCRIPTION
reason: actions run from dependabot PRs can't access secrets ([source](https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/)) which causes the SonarQube action to fail ([example](https://github.com/vitruv-tools/Vitruv-DSLs/pull/145))