### PR TITLE
ci: bump actions/upload to version 4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,11 +48,21 @@ jobs:
       if: matrix.os == 'windows-latest'
       run: mkdir staging-${{ matrix.os }} && gci -Path . -Recurse -Include *.jar |? { $_.FullName -like '*\target\*.jar' } |% { cp $_.FullName staging-${{ matrix.os }} }
 
-    - name: Upload build results
-      uses: actions/upload-artifact@v3.2.1
+    - name: Upload build results to temporary files
+      uses: actions/upload-artifact@v4
       with:
-        name: Build Results
+        name: temp-results-${{ matrix.os }}
         path: staging-*/
+
+  upload:
+    runs-on: ubuntu-latest
+    needs: verify
+    steps:
+      - name: Upload build results
+        uses: actions/upload-artifact/merge@v4
+        with:
+          name: Build Results
+          pattern: temp-results-*
 
   verify-javadoc:
     name: Verify JavaDoc


### PR DESCRIPTION
Preserve previous behavior (upload _all_ results for each OS) by using
the merge action in a new build step.

Closes #121.