### PR TITLE
refactor p2 dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@
 target/
 *.log
 .mvn/wrapper/*.jar
+.flattened-pom.xml
+dependency-reduced-pom.xml
 
 # Eclipse
 META-INF

--- a/atomic/pom.xml
+++ b/atomic/pom.xml
@@ -81,14 +81,6 @@
       <groupId>org.eclipse.xtext</groupId>
       <artifactId>org.eclipse.xtext.xbase.lib</artifactId>
     </dependency>
-    <dependency>
-      <groupId>sdq-commons</groupId>
-      <artifactId>edu.kit.ipd.sdq.commons.util.emf</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>xannotations</groupId>
-      <artifactId>edu.kit.ipd.sdq.activextendannotations</artifactId>
-    </dependency>
 
     <!-- external test dependencies -->
     <dependency>
@@ -111,9 +103,24 @@
       <artifactId>junit-jupiter-params</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <!-- p2 compile dependencies -->
     <dependency>
-      <groupId>sdq-commons</groupId>
-      <artifactId>edu.kit.ipd.sdq.commons.util.java</artifactId>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>tools.vitruv.change.p2wrappers.activextendannotations</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>tools.vitruv.change.p2wrappers.emfutils</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <!-- p2 test dependencies -->
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>tools.vitruv.change.p2wrappers.javautils</artifactId>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/changederivation/pom.xml
+++ b/changederivation/pom.xml
@@ -48,10 +48,6 @@
       <artifactId>guava</artifactId>
     </dependency>
     <dependency>
-      <groupId>emf-compare</groupId>
-      <artifactId>org.eclipse.emf.compare</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.eclipse.emf</groupId>
       <artifactId>org.eclipse.emf.common</artifactId>
     </dependency>
@@ -63,9 +59,17 @@
       <groupId>org.eclipse.xtext</groupId>
       <artifactId>org.eclipse.xtext.xbase.lib</artifactId>
     </dependency>
+
+    <!-- p2 dependencies -->
     <dependency>
-      <groupId>sdq-commons</groupId>
-      <artifactId>edu.kit.ipd.sdq.commons.util.emf</artifactId>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>tools.vitruv.change.p2wrappers.emfcompare</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>tools.vitruv.change.p2wrappers.emfutils</artifactId>
+      <version>${project.version}</version>
     </dependency>
   </dependencies>
 </project>

--- a/composite/pom.xml
+++ b/composite/pom.xml
@@ -81,18 +81,6 @@
       <groupId>org.eclipse.xtext</groupId>
       <artifactId>org.eclipse.xtext.xbase.lib</artifactId>
     </dependency>
-    <dependency>
-      <groupId>sdq-commons</groupId>
-      <artifactId>edu.kit.ipd.sdq.commons.util.emf</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>sdq-commons</groupId>
-      <artifactId>edu.kit.ipd.sdq.commons.util.java</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>xannotations</groupId>
-      <artifactId>edu.kit.ipd.sdq.activextendannotations</artifactId>
-    </dependency>
 
     <!-- external test dependencies -->
     <dependency>
@@ -109,6 +97,23 @@
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-params</artifactId>
       <scope>test</scope>
+    </dependency>
+
+    <!-- p2 compile dependencies -->
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>tools.vitruv.change.p2wrappers.activextendannotations</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>tools.vitruv.change.p2wrappers.emfutils</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>tools.vitruv.change.p2wrappers.javautils</artifactId>
+      <version>${project.version}</version>
     </dependency>
   </dependencies>
 </project>

--- a/correspondence/pom.xml
+++ b/correspondence/pom.xml
@@ -73,10 +73,6 @@
       <groupId>org.eclipse.emf</groupId>
       <artifactId>org.eclipse.emf.ecore</artifactId>
     </dependency>
-    <dependency>
-      <groupId>sdq-commons</groupId>
-      <artifactId>edu.kit.ipd.sdq.commons.util.emf</artifactId>
-    </dependency>
 
     <!-- external test dependencies -->
     <dependency>
@@ -89,9 +85,19 @@
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <!-- p2 compile dependencies -->
     <dependency>
-      <groupId>sdq-commons</groupId>
-      <artifactId>edu.kit.ipd.sdq.commons.util.java</artifactId>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>tools.vitruv.change.p2wrappers.emfutils</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <!-- p2 test dependencies -->
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>tools.vitruv.change.p2wrappers.javautils</artifactId>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/interaction/pom.xml
+++ b/interaction/pom.xml
@@ -58,9 +58,12 @@
       <groupId>org.eclipse.xtext</groupId>
       <artifactId>org.eclipse.xtext.xbase.lib</artifactId>
     </dependency>
+
+    <!-- p2 dependencies -->
     <dependency>
-      <groupId>sdq-commons</groupId>
-      <artifactId>edu.kit.ipd.sdq.commons.util.java</artifactId>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>tools.vitruv.change.p2wrappers.javautils</artifactId>
+      <version>${project.version}</version>
     </dependency>
   </dependencies>
 </project>

--- a/p2wrappers/activextendannotations/pom.xml
+++ b/p2wrappers/activextendannotations/pom.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>tools.vitruv</groupId>
+    <artifactId>tools.vitruv.change.p2wrappers</artifactId>
+    <version>3.2.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>tools.vitruv.change.p2wrappers.activextendannotations</artifactId>
+
+  <name>p2 Dependency Wrapper Active Xtend Annotations</name>
+  <description />
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.openntf.maven</groupId>
+        <artifactId>p2-layout-resolver</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>flatten-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <artifactId>maven-shade-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+
+  <properties>
+    <repo.xannotations.version>1.6.0</repo.xannotations.version>
+  </properties>
+
+  <repositories>
+    <repository>
+      <id>xannotations</id>
+      <name>XAnnotations</name>
+      <layout>p2</layout>
+      <url>https://kit-sdq.github.io/updatesite/release/xannotations/${repo.xannotations.version}</url>
+    </repository>
+  </repositories>
+
+  <dependencies>
+    <dependency>
+      <groupId>xannotations</groupId>
+      <artifactId>edu.kit.ipd.sdq.activextendannotations</artifactId>
+      <version>1.6.0</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/p2wrappers/eclipseutils/pom.xml
+++ b/p2wrappers/eclipseutils/pom.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>tools.vitruv</groupId>
+    <artifactId>tools.vitruv.change.p2wrappers</artifactId>
+    <version>3.2.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>tools.vitruv.change.p2wrappers.eclipseutils</artifactId>
+
+  <name>p2 Dependency Wrapper Eclipse Utils</name>
+  <description />
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.openntf.maven</groupId>
+        <artifactId>p2-layout-resolver</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>flatten-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <artifactId>maven-shade-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+
+  <properties>
+    <repo.sdq-commons.version>2.2.0</repo.sdq-commons.version>
+  </properties>
+
+  <repositories>
+    <repository>
+      <id>sdq-commons</id>
+      <name>SDQ Commons</name>
+      <url>https://kit-sdq.github.io/updatesite/release/commons/${repo.sdq-commons.version}</url>
+      <layout>p2</layout>
+    </repository>
+  </repositories>
+
+  <dependencies>
+    <dependency>
+      <groupId>sdq-commons</groupId>
+      <artifactId>edu.kit.ipd.sdq.commons.util.eclipse</artifactId>
+      <version>2.3.0.202304271319</version>
+      <exclusions>
+        <!-- exclude unnecessary transitive dependencies from sdq-commons p2 repository -->
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+  </dependencies>
+</project>

--- a/p2wrappers/emfcompare/pom.xml
+++ b/p2wrappers/emfcompare/pom.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>tools.vitruv</groupId>
+    <artifactId>tools.vitruv.change.p2wrappers</artifactId>
+    <version>3.2.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>tools.vitruv.change.p2wrappers.emfcompare</artifactId>
+
+  <name>p2 Dependency Wrapper EMF Compare</name>
+  <description />
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.openntf.maven</groupId>
+        <artifactId>p2-layout-resolver</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>flatten-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <artifactId>maven-shade-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+
+  <properties>
+    <repo.emf-compare.version>3.3</repo.emf-compare.version>
+  </properties>
+
+  <repositories>
+    <repository>
+      <id>emf-compare</id>
+      <name>EMF Compare</name>
+      <layout>p2</layout>
+      <url>https://download.eclipse.org/modeling/emf/compare/updates/releases/${repo.emf-compare.version}</url>
+    </repository>
+  </repositories>
+
+  <dependencies>
+    <dependency>
+      <groupId>emf-compare</groupId>
+      <artifactId>org.eclipse.emf.compare</artifactId>
+      <version>3.5.3.202212280858</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/p2wrappers/emfutils/pom.xml
+++ b/p2wrappers/emfutils/pom.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>tools.vitruv</groupId>
+    <artifactId>tools.vitruv.change.p2wrappers</artifactId>
+    <version>3.2.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>tools.vitruv.change.p2wrappers.emfutils</artifactId>
+
+  <name>p2 Dependency Wrapper EMF Utils</name>
+  <description />
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.openntf.maven</groupId>
+        <artifactId>p2-layout-resolver</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>flatten-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <artifactId>maven-shade-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+
+  <properties>
+    <repo.sdq-commons.version>2.2.0</repo.sdq-commons.version>
+  </properties>
+
+  <repositories>
+    <repository>
+      <id>sdq-commons</id>
+      <name>SDQ Commons</name>
+      <url>https://kit-sdq.github.io/updatesite/release/commons/${repo.sdq-commons.version}</url>
+      <layout>p2</layout>
+    </repository>
+  </repositories>
+
+  <dependencies>
+    <dependency>
+      <groupId>sdq-commons</groupId>
+      <artifactId>edu.kit.ipd.sdq.commons.util.emf</artifactId>
+      <version>2.3.0.202304271319</version>
+      <exclusions>
+        <!-- exclude unnecessary transitive dependencies from sdq-commons p2 repository -->
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+  </dependencies>
+</project>

--- a/p2wrappers/javautils/pom.xml
+++ b/p2wrappers/javautils/pom.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>tools.vitruv</groupId>
+    <artifactId>tools.vitruv.change.p2wrappers</artifactId>
+    <version>3.2.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>tools.vitruv.change.p2wrappers.javautils</artifactId>
+
+  <name>p2 Dependency Wrapper Java Utils</name>
+  <description />
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.openntf.maven</groupId>
+        <artifactId>p2-layout-resolver</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>flatten-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <artifactId>maven-shade-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+
+  <properties>
+    <repo.sdq-commons.version>2.2.0</repo.sdq-commons.version>
+  </properties>
+
+  <repositories>
+    <repository>
+      <id>sdq-commons</id>
+      <name>SDQ Commons</name>
+      <url>https://kit-sdq.github.io/updatesite/release/commons/${repo.sdq-commons.version}</url>
+      <layout>p2</layout>
+    </repository>
+  </repositories>
+
+  <dependencies>
+    <dependency>
+      <groupId>sdq-commons</groupId>
+      <artifactId>edu.kit.ipd.sdq.commons.util.java</artifactId>
+      <version>2.3.0.202304271319</version>
+      <exclusions>
+        <!-- exclude unnecessary transitive dependencies from sdq-commons p2 repository -->
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+  </dependencies>
+</project>

--- a/p2wrappers/pom.xml
+++ b/p2wrappers/pom.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>tools.vitruv</groupId>
+    <artifactId>tools.vitruv.change</artifactId>
+    <version>3.2.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>tools.vitruv.change.p2wrappers</artifactId>
+  <packaging>pom</packaging>
+
+  <name>p2 Dependency Wrappers</name>
+  <description />
+
+  <modules>
+    <module>activextendannotations</module>
+    <module>eclipseutils</module>
+    <module>emfcompare</module>
+    <module>emfutils</module>
+    <module>javautils</module>
+  </modules>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <!-- allow Eclipse updatesites as repositories -->
+        <plugin>
+          <groupId>org.openntf.maven</groupId>
+          <artifactId>p2-layout-resolver</artifactId>
+          <version>1.9.0</version>
+          <extensions>true</extensions>
+        </plugin>
+        <!-- generate empty javadoc JARs for deployment -->
+        <plugin>
+          <artifactId>maven-jar-plugin</artifactId>
+          <version>3.4.2</version>
+          <executions>
+            <execution>
+              <id>javadoc-jar</id>
+              <phase>package</phase>
+              <goals>
+                <goal>jar</goal>
+              </goals>
+              <configuration>
+                <classifier>javadoc</classifier>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
+  <pluginRepositories>
+    <!-- required for the p2-layout-resolver plugin -->
+    <pluginRepository>
+      <id>artifactory.openntf.org</id>
+      <name>artifactory.openntf.org</name>
+      <url>https://artifactory.openntf.org/openntf</url>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </pluginRepository>
+  </pluginRepositories>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -46,59 +46,15 @@
     <module>propagation</module>
     <module>testutils</module>
     <module>utils</module>
+    <module>p2wrappers</module>
   </modules>
 
   <properties>
-    <!-- Additional Repositories -->
-    <repo.emf-compare.version>3.3</repo.emf-compare.version>
-    <repo.sdq-commons.version>2.2.0</repo.sdq-commons.version>
-    <repo.xannotations.version>1.6.0</repo.xannotations.version>
     <!-- SonarQube configuration -->
     <sonar.host.url>https://sonarcloud.io</sonar.host.url>
     <sonar.organization>vitruv-tools</sonar.organization>
     <sonar.projectKey>vitruv-tools_Vitruv-Change</sonar.projectKey>
   </properties>
-
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.openntf.maven</groupId>
-        <artifactId>p2-layout-resolver</artifactId>
-      </plugin>
-    </plugins>
-  </build>
-
-  <repositories>
-    <!-- Maven Central should have priority -->
-    <repository>
-      <id>central</id>
-      <name>Maven Central</name>
-      <url>https://repo1.maven.org/maven2/</url>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </repository>
-
-    <!-- for p2 dependencies, `groupId` specifies the repository -->
-    <repository>
-      <id>emf-compare</id>
-      <name>EMF Compare</name>
-      <layout>p2</layout>
-      <url>https://download.eclipse.org/modeling/emf/compare/updates/releases/${repo.emf-compare.version}</url>
-    </repository>
-    <repository>
-      <id>sdq-commons</id>
-      <name>SDQ Commons</name>
-      <url>https://kit-sdq.github.io/updatesite/release/commons/${repo.sdq-commons.version}</url>
-      <layout>p2</layout>
-    </repository>
-    <repository>
-      <id>xannotations</id>
-      <name>XAnnotations</name>
-      <layout>p2</layout>
-      <url>https://kit-sdq.github.io/updatesite/release/xannotations/${repo.xannotations.version}</url>
-    </repository>
-  </repositories>
 
   <!-- Dependency Management -->
   <dependencyManagement>
@@ -107,11 +63,6 @@
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
         <version>33.4.0-jre</version>
-      </dependency>
-      <dependency>
-        <groupId>emf-compare</groupId>
-        <artifactId>org.eclipse.emf.compare</artifactId>
-        <version>3.5.3.202212280858</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
@@ -197,47 +148,6 @@
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
         <version>2.0.16</version>
-      </dependency>
-      <dependency>
-        <groupId>sdq-commons</groupId>
-        <artifactId>edu.kit.ipd.sdq.commons.util.eclipse</artifactId>
-        <version>2.3.0.202304271319</version>
-        <exclusions>
-          <!-- exclude unnecessary transitive dependencies from sdq-commons p2 repository -->
-          <exclusion>
-            <groupId>*</groupId>
-            <artifactId>*</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>sdq-commons</groupId>
-        <artifactId>edu.kit.ipd.sdq.commons.util.emf</artifactId>
-        <version>2.3.0.202304271319</version>
-        <exclusions>
-          <!-- exclude unnecessary transitive dependencies from sdq-commons p2 repository -->
-          <exclusion>
-            <groupId>*</groupId>
-            <artifactId>*</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>sdq-commons</groupId>
-        <artifactId>edu.kit.ipd.sdq.commons.util.java</artifactId>
-        <version>2.3.0.202304271319</version>
-        <exclusions>
-          <!-- exclude unnecessary transitive dependencies from sdq-commons p2 repository -->
-          <exclusion>
-            <groupId>*</groupId>
-            <artifactId>*</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>xannotations</groupId>
-        <artifactId>edu.kit.ipd.sdq.activextendannotations</artifactId>
-        <version>1.6.0</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>tools.vitruv</groupId>
     <artifactId>parent</artifactId>
-    <version>3.0.6</version>
+    <version>3.0.7</version>
   </parent>
 
   <!-- Project Information -->

--- a/propagation/pom.xml
+++ b/propagation/pom.xml
@@ -87,13 +87,17 @@
       <groupId>org.eclipse.xtext</groupId>
       <artifactId>org.eclipse.xtext.xbase.lib</artifactId>
     </dependency>
+
+    <!-- p2 dependencies -->
     <dependency>
-      <groupId>sdq-commons</groupId>
-      <artifactId>edu.kit.ipd.sdq.commons.util.emf</artifactId>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>tools.vitruv.change.p2wrappers.emfutils</artifactId>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>sdq-commons</groupId>
-      <artifactId>edu.kit.ipd.sdq.commons.util.java</artifactId>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>tools.vitruv.change.p2wrappers.javautils</artifactId>
+      <version>${project.version}</version>
     </dependency>
   </dependencies>
 </project>

--- a/testutils/core/pom.xml
+++ b/testutils/core/pom.xml
@@ -51,10 +51,6 @@
       <artifactId>guava</artifactId>
     </dependency>
     <dependency>
-      <groupId>emf-compare</groupId>
-      <artifactId>org.eclipse.emf.compare</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
     </dependency>
@@ -107,28 +103,39 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
-    <dependency>
-      <groupId>sdq-commons</groupId>
-      <artifactId>edu.kit.ipd.sdq.commons.util.eclipse</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>sdq-commons</groupId>
-      <artifactId>edu.kit.ipd.sdq.commons.util.emf</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>sdq-commons</groupId>
-      <artifactId>edu.kit.ipd.sdq.commons.util.java</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>xannotations</groupId>
-      <artifactId>edu.kit.ipd.sdq.activextendannotations</artifactId>
-    </dependency>
 
     <!-- external test dependencies -->
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-params</artifactId>
       <scope>test</scope>
+    </dependency>
+
+    <!-- p2 compile dependencies-->
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>tools.vitruv.change.p2wrappers.activextendannotations</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>tools.vitruv.change.p2wrappers.eclipseutils</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>tools.vitruv.change.p2wrappers.emfcompare</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>tools.vitruv.change.p2wrappers.emfutils</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>tools.vitruv.change.p2wrappers.javautils</artifactId>
+      <version>${project.version}</version>
     </dependency>
   </dependencies>
 </project>

--- a/testutils/integration/pom.xml
+++ b/testutils/integration/pom.xml
@@ -78,18 +78,6 @@
       <groupId>org.eclipse.xtext</groupId>
       <artifactId>org.eclipse.xtext.xbase.lib</artifactId>
     </dependency>
-    <dependency>
-      <groupId>sdq-commons</groupId>
-      <artifactId>edu.kit.ipd.sdq.commons.util.emf</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>sdq-commons</groupId>
-      <artifactId>edu.kit.ipd.sdq.commons.util.java</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>xannotations</groupId>
-      <artifactId>edu.kit.ipd.sdq.activextendannotations</artifactId>
-    </dependency>
 
     <!-- external test dependencies -->
     <dependency>
@@ -101,6 +89,23 @@
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
+    </dependency>
+
+    <!-- p2 compile dependencies -->
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>tools.vitruv.change.p2wrappers.activextendannotations</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>tools.vitruv.change.p2wrappers.emfutils</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>tools.vitruv.change.p2wrappers.javautils</artifactId>
+      <version>${project.version}</version>
     </dependency>
   </dependencies>
 </project>

--- a/testutils/metamodels/pom.xml
+++ b/testutils/metamodels/pom.xml
@@ -70,9 +70,12 @@
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-params</artifactId>
     </dependency>
+
+    <!-- p2 dependencies -->
     <dependency>
-      <groupId>xannotations</groupId>
-      <artifactId>edu.kit.ipd.sdq.activextendannotations</artifactId>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>tools.vitruv.change.p2wrappers.activextendannotations</artifactId>
+      <version>${project.version}</version>
     </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
re-package p2 dependencies in wrapper JARs to make them available for users without having to support p2 repositories themselves

depends on the next release of https://github.com/vitruv-tools/Maven-Build-Parent