### PR TITLE
fill empty description for p2 wrapper modules

### DIFF
--- a/p2wrappers/activextendannotations/pom.xml
+++ b/p2wrappers/activextendannotations/pom.xml
@@ -14,7 +14,7 @@
   <artifactId>tools.vitruv.change.p2wrappers.activextendannotations</artifactId>
 
   <name>p2 Dependency Wrapper Active Xtend Annotations</name>
-  <description />
+  <description>wrapper for the p2 dependency xannotations:edu.kit.ipd.sdq.activextendannotations</description>
 
   <build>
     <plugins>

--- a/p2wrappers/eclipseutils/pom.xml
+++ b/p2wrappers/eclipseutils/pom.xml
@@ -14,7 +14,7 @@
   <artifactId>tools.vitruv.change.p2wrappers.eclipseutils</artifactId>
 
   <name>p2 Dependency Wrapper Eclipse Utils</name>
-  <description />
+  <description>wrapper for the p2 dependency sdq-commons:edu.kit.ipd.sdq.commons.util.eclipse</description>
 
   <build>
     <plugins>

--- a/p2wrappers/emfcompare/pom.xml
+++ b/p2wrappers/emfcompare/pom.xml
@@ -14,7 +14,7 @@
   <artifactId>tools.vitruv.change.p2wrappers.emfcompare</artifactId>
 
   <name>p2 Dependency Wrapper EMF Compare</name>
-  <description />
+  <description>wrapper for the p2 dependency emf-compare:org.eclipse.emf.compare</description>
 
   <build>
     <plugins>

--- a/p2wrappers/emfutils/pom.xml
+++ b/p2wrappers/emfutils/pom.xml
@@ -14,7 +14,7 @@
   <artifactId>tools.vitruv.change.p2wrappers.emfutils</artifactId>
 
   <name>p2 Dependency Wrapper EMF Utils</name>
-  <description />
+  <description>wrapper for the p2 dependency sdq-commons:edu.kit.ipd.sdq.commons.util.emf</description>
 
   <build>
     <plugins>

--- a/p2wrappers/javautils/pom.xml
+++ b/p2wrappers/javautils/pom.xml
@@ -14,7 +14,7 @@
   <artifactId>tools.vitruv.change.p2wrappers.javautils</artifactId>
 
   <name>p2 Dependency Wrapper Java Utils</name>
-  <description />
+  <description>wrapper for the p2 dependency sdq-commons:edu.kit.ipd.sdq.commons.util.java</description>
 
   <build>
     <plugins>


### PR DESCRIPTION
apparently wrapping the dependencies removes empty description tags which causes the release build to fail