### PR TITLE
fix: break class dependency cycle

### DIFF
--- a/changederivation/src/main/xtend/tools/vitruv/change/changederivation/AbstractStateBasedChangeResolutionStrategy.xtend
+++ b/changederivation/src/main/xtend/tools/vitruv/change/changederivation/AbstractStateBasedChangeResolutionStrategy.xtend
@@ -17,6 +17,7 @@ import org.eclipse.emf.ecore.resource.Resource
 import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl
 import org.eclipse.emf.ecore.util.EcoreUtil
 import tools.vitruv.change.composite.description.VitruviusChangeResolver
+import tools.vitruv.change.composite.description.VitruviusChangeResolverFactory
 import tools.vitruv.change.composite.recording.ChangeRecorder
 
 import static com.google.common.base.Preconditions.checkArgument
@@ -80,7 +81,7 @@ abstract class AbstractStateBasedChangeResolutionStrategy implements StateBasedC
             changeRecorder.addToRecording(resource)
             function.apply()
             val recordedChanges = changeRecorder.endRecording
-            val changeResolver = VitruviusChangeResolver.forHierarchicalIds(resource.resourceSet)
+            val changeResolver = VitruviusChangeResolverFactory.forHierarchicalIds(resource.resourceSet)
             return changeResolver.assignIds(recordedChanges)
         }
     }

--- a/changederivation/src/main/xtend/tools/vitruv/change/changederivation/persistence/DeltaBasedResource.xtend
+++ b/changederivation/src/main/xtend/tools/vitruv/change/changederivation/persistence/DeltaBasedResource.xtend
@@ -13,6 +13,7 @@ import tools.vitruv.change.atomic.EChange
 import tools.vitruv.change.atomic.hid.HierarchicalId
 import tools.vitruv.change.composite.description.VitruviusChangeFactory
 import tools.vitruv.change.composite.description.VitruviusChangeResolver
+import tools.vitruv.change.composite.description.VitruviusChangeResolverFactory
 
 import static edu.kit.ipd.sdq.commons.util.org.eclipse.emf.ecore.resource.ResourceSetUtil.withGlobalFactories
 
@@ -36,7 +37,7 @@ class DeltaBasedResource extends ResourceImpl {
 
 	override doLoad(InputStream inputStream, Map<?, ?> options) throws IOException {
 		val deltas = loadDeltas(this.URI)
-		VitruviusChangeResolver.forHierarchicalIds(resourceSet).resolveAndApply(
+		VitruviusChangeResolverFactory.forHierarchicalIds(resourceSet).resolveAndApply(
 			VitruviusChangeFactory.getInstance().createTransactionalChange(deltas))
 	}
 	

--- a/composite/src/main/java/tools/vitruv/change/composite/description/VitruviusChangeResolver.java
+++ b/composite/src/main/java/tools/vitruv/change/composite/description/VitruviusChangeResolver.java
@@ -1,15 +1,6 @@
 package tools.vitruv.change.composite.description;
 
 import org.eclipse.emf.ecore.EObject;
-import org.eclipse.emf.ecore.resource.ResourceSet;
-
-import tools.vitruv.change.atomic.hid.AtomicEChangeHierarchicalIdResolver;
-import tools.vitruv.change.atomic.hid.HierarchicalId;
-import tools.vitruv.change.atomic.uuid.AtomicEChangeUuidResolver;
-import tools.vitruv.change.atomic.uuid.Uuid;
-import tools.vitruv.change.atomic.uuid.UuidResolver;
-import tools.vitruv.change.composite.description.impl.VitruviusChangeHierarchicalIdResolver;
-import tools.vitruv.change.composite.description.impl.VitruviusChangeUuidResolver;
 
 public interface VitruviusChangeResolver<Id> {
 	/**
@@ -28,24 +19,4 @@ public interface VitruviusChangeResolver<Id> {
 	 * Id-assigned change.
 	 */
 	public VitruviusChange<Id> assignIds(VitruviusChange<EObject> change);
-
-	/**
-	 * Instantiates a new resolver that uses {@link Uuid UUIDs}.
-	 * 
-	 * @param uuidResolver the {@link UuidResolver} to resolve UUIDs with.
-	 */
-	public static VitruviusChangeResolver<Uuid> forUuids(UuidResolver uuidResolver) {
-		AtomicEChangeUuidResolver resolver = new AtomicEChangeUuidResolver(uuidResolver);
-		return new VitruviusChangeUuidResolver(resolver);
-	}
-
-	/**
-	 * Instantiates a new resolver that uses {@link HierarchicalId HierarchicalIds}.
-	 * 
-	 * @param resourceSet the {@link ResourceSet} to use with this resolver.
-	 */
-	public static VitruviusChangeResolver<HierarchicalId> forHierarchicalIds(ResourceSet resourceSet) {
-		AtomicEChangeHierarchicalIdResolver resolver = new AtomicEChangeHierarchicalIdResolver(resourceSet);
-		return new VitruviusChangeHierarchicalIdResolver(resolver);
-	}
 }

--- a/composite/src/main/java/tools/vitruv/change/composite/description/VitruviusChangeResolverFactory.java
+++ b/composite/src/main/java/tools/vitruv/change/composite/description/VitruviusChangeResolverFactory.java
@@ -1,0 +1,43 @@
+package tools.vitruv.change.composite.description;
+
+import org.eclipse.emf.ecore.resource.ResourceSet;
+
+import tools.vitruv.change.atomic.hid.AtomicEChangeHierarchicalIdResolver;
+import tools.vitruv.change.atomic.hid.HierarchicalId;
+import tools.vitruv.change.atomic.uuid.AtomicEChangeUuidResolver;
+import tools.vitruv.change.atomic.uuid.Uuid;
+import tools.vitruv.change.atomic.uuid.UuidResolver;
+import tools.vitruv.change.composite.description.impl.VitruviusChangeHierarchicalIdResolver;
+import tools.vitruv.change.composite.description.impl.VitruviusChangeUuidResolver;
+
+/**
+ * Factory class to instantiate implementations of a {@link VitruviusChangeResolver}.
+ * 
+ * @author Benedikt Jutz
+ */
+public class VitruviusChangeResolverFactory {
+    /**
+     * Private constructor to prevent instantiation.
+     */
+    private VitruviusChangeResolverFactory() {}
+
+    /**
+     * Instantiates a new resolver that uses {@link Uuid UUIDs}.
+     * 
+     * @param uuidResolver the {@link UuidResolver} to resolve UUIDs with.
+     */
+    public static VitruviusChangeResolver<Uuid> forUuids(UuidResolver uuidResolver) {
+    	AtomicEChangeUuidResolver resolver = new AtomicEChangeUuidResolver(uuidResolver);
+    	return new VitruviusChangeUuidResolver(resolver);
+    }
+
+    /**
+     * Instantiates a new resolver that uses {@link HierarchicalId HierarchicalIds}.
+     * 
+     * @param resourceSet the {@link ResourceSet} to use with this resolver.
+     */
+    public static VitruviusChangeResolver<HierarchicalId> forHierarchicalIds(ResourceSet resourceSet) {
+    	AtomicEChangeHierarchicalIdResolver resolver = new AtomicEChangeHierarchicalIdResolver(resourceSet);
+    	return new VitruviusChangeHierarchicalIdResolver(resolver);
+    }
+}

--- a/composite/src/test/xtend/tools/vitruv/change/composite/ChangeDescription2ChangeTransformationTest.xtend
+++ b/composite/src/test/xtend/tools/vitruv/change/composite/ChangeDescription2ChangeTransformationTest.xtend
@@ -17,6 +17,7 @@ import tools.vitruv.change.atomic.uuid.Uuid
 import tools.vitruv.change.atomic.uuid.UuidResolver
 import tools.vitruv.change.composite.description.VitruviusChange
 import tools.vitruv.change.composite.description.VitruviusChangeResolver
+import tools.vitruv.change.composite.description.VitruviusChangeResolverFactory
 import tools.vitruv.change.composite.recording.ChangeRecorder
 import tools.vitruv.change.testutils.RegisterMetamodelsInStandalone
 import tools.vitruv.change.testutils.TestProject
@@ -52,7 +53,7 @@ abstract class ChangeDescription2ChangeTransformationTest {
 		this.resourceSet = new ResourceSetImpl().withGlobalFactories()
 		this.uuidResolver = UuidResolver.create(resourceSet)
 		this.changeRecorder = new ChangeRecorder(resourceSet)
-		this.changeResolver = VitruviusChangeResolver.forUuids(uuidResolver);
+		this.changeResolver = VitruviusChangeResolverFactory.forUuids(uuidResolver);
 		this.resourceSet.startRecording
 	}
 
@@ -124,7 +125,7 @@ abstract class ChangeDescription2ChangeTransformationTest {
 		val comparisonResourceSet = new ResourceSetImpl().withGlobalFactories()
 		val originalToComparisonResourceMapping = resourceSet.copyTo(comparisonResourceSet)
 		val comparisonUuidResolver = UuidResolver.create(comparisonResourceSet)
-		val comparisonChangeResolver = VitruviusChangeResolver.forUuids(comparisonUuidResolver)
+		val comparisonChangeResolver = VitruviusChangeResolverFactory.forUuids(comparisonUuidResolver)
 		uuidResolver.resolveResources(originalToComparisonResourceMapping, comparisonUuidResolver)
 		operationToValidate.apply [ unresolvedChange |
 			comparisonChangeResolver.resolveAndApply(unresolvedChange)

--- a/propagation/src/main/java/tools/vitruv/change/propagation/impl/DefaultChangeRecordingModelRepository.java
+++ b/propagation/src/main/java/tools/vitruv/change/propagation/impl/DefaultChangeRecordingModelRepository.java
@@ -24,6 +24,7 @@ import tools.vitruv.change.atomic.uuid.UuidResolver;
 import tools.vitruv.change.composite.description.TransactionalChange;
 import tools.vitruv.change.composite.description.VitruviusChange;
 import tools.vitruv.change.composite.description.VitruviusChangeResolver;
+import tools.vitruv.change.composite.description.VitruviusChangeResolverFactory;
 import tools.vitruv.change.composite.recording.ChangeRecorder;
 import tools.vitruv.change.correspondence.Correspondence;
 import tools.vitruv.change.correspondence.model.PersistableCorrespondenceModel;
@@ -74,7 +75,7 @@ public class DefaultChangeRecordingModelRepository implements PersistableChangeR
 		this.consistencyMetadataFolder = consistencyMetadataFolder;
 		this.modelsResourceSet = withGlobalFactories(new ResourceSetImpl());
 		this.uuidResolver = UuidResolver.create(modelsResourceSet);
-		this.changeResolver = VitruviusChangeResolver.forUuids(uuidResolver);
+		this.changeResolver = VitruviusChangeResolverFactory.forUuids(uuidResolver);
 		this.correspondenceModel = createPersistableCorrespondenceModel(correspondencesURI);
 		this.modelsResourceSet.eAdapters().add(new ResourceRegistrationAdapter((resource) -> {
 			if (!isLoading) {

--- a/testutils/integration/src/main/xtend/tools/vitruv/change/testutils/views/ChangePublishingTestView.xtend
+++ b/testutils/integration/src/main/xtend/tools/vitruv/change/testutils/views/ChangePublishingTestView.xtend
@@ -19,6 +19,7 @@ import tools.vitruv.change.atomic.uuid.UuidResolver
 import tools.vitruv.change.composite.description.PropagatedChange
 import tools.vitruv.change.composite.description.TransactionalChange
 import tools.vitruv.change.composite.description.VitruviusChangeResolver
+import tools.vitruv.change.composite.description.VitruviusChangeResolverFactory
 import tools.vitruv.change.composite.propagation.ChangeableModelRepository
 import tools.vitruv.change.composite.recording.ChangeRecorder
 import tools.vitruv.change.propagation.ChangePropagationSpecification
@@ -72,7 +73,7 @@ class ChangePublishingTestView implements NonTransactionalTestView {
 		this.modelRepository = changeableModelRepository
 		this.delegate = new BasicTestView(persistenceDirectory, resourceSet, userInteraction, uriMode)
 		this.changeRecorder = new ChangeRecorder(resourceSet)
-		this.changeResolver = VitruviusChangeResolver.forUuids(uuidResolver)
+		this.changeResolver = VitruviusChangeResolverFactory.forUuids(uuidResolver)
 		this.uuidResolution = uuidResolution
 		changeRecorder.beginRecording()
 	}


### PR DESCRIPTION
Extracted creation methods of VitruviusChangeResolver implementations
into the new singleton factory class VitruviusChangeResolverFactory.

Closes #142.