### PR TITLE
un-ignore vitruv-tools dependencies in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,6 @@ updates:
   directory: "/"
   schedule:
     interval: daily
-  ignore:
-    - dependency-name: tools.vitruv:*
   commit-message:
     prefix: "Maven"
     include: "scope"


### PR DESCRIPTION
not really relevant, but also not needed