### PR TITLE
Issue194

### DIFF
--- a/atomic/src/main/java/tools/vitruv/change/atomic/uuid/UuidResolver.java
+++ b/atomic/src/main/java/tools/vitruv/change/atomic/uuid/UuidResolver.java
@@ -7,7 +7,6 @@ import java.util.Map;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.resource.Resource;
-import org.eclipse.emf.ecore.resource.ResourceSet;
 
 /**
  * A UUID resolver manages the mapping of {@link org.eclipse.emf.ecore.EObject} to UUIDs within one
@@ -148,16 +147,6 @@ public interface UuidResolver {
     checkState(sourceResource != null, "source resource must not be null");
     checkState(targetResource != null, "target resource must not be null");
     resolveResources(Map.of(sourceResource, targetResource), targetUuidResolver);
-  }
-
-  /**
-   * Creates a new {@link UuidResolver} with the given resource set.
-   *
-   * @param resourceSet is the resource set the UUID resolver uses.
-   * @return a new {@link UuidResolver} instance.
-   */
-  public static UuidResolver create(ResourceSet resourceSet) {
-    return new UuidResolverImpl(resourceSet);
   }
 
   /**

--- a/atomic/src/main/java/tools/vitruv/change/atomic/uuid/UuidResolverFactory.java
+++ b/atomic/src/main/java/tools/vitruv/change/atomic/uuid/UuidResolverFactory.java
@@ -8,19 +8,19 @@ import org.eclipse.emf.ecore.resource.ResourceSet;
  * @author Maik Sept
  */
 public class UuidResolverFactory {
-	
-	/**
-	 * Private constructor to prevent instantiation.
-	 */
-	private UuidResolverFactory() {}
-	
-	/**
-	 * Creates a new {@link UuidResolver} with the given resource set.
-	 * 
-	 * @param resourceSet is the resource set the UUID resolver uses.
-	 * @return a new {@link UuidResolver} instance.
-	 */
-	public static UuidResolver create(ResourceSet resourceSet) {
-		return new UuidResolverImpl(resourceSet);
-	}
+  
+  /**
+   * Private constructor to prevent instantiation.
+   */
+  private UuidResolverFactory() {}
+  
+  /**
+   * Creates a new {@link UuidResolver} with the given resource set.
+   *
+   * @param resourceSet is the resource set the UUID resolver uses.
+   * @return a new {@link UuidResolver} instance.
+   */
+  public static UuidResolver create(ResourceSet resourceSet) {
+    return new UuidResolverImpl(resourceSet);
+  }
 }

--- a/atomic/src/main/java/tools/vitruv/change/atomic/uuid/UuidResolverFactory.java
+++ b/atomic/src/main/java/tools/vitruv/change/atomic/uuid/UuidResolverFactory.java
@@ -1,0 +1,26 @@
+package tools.vitruv.change.atomic.uuid;
+
+import org.eclipse.emf.ecore.resource.ResourceSet;
+
+/**
+ * Factory class to instantiate implementations of a {@link UuidResolver}.
+ *
+ * @author Maik Sept
+ */
+public class UuidResolverFactory {
+	
+	/**
+	 * Private constructor to prevent instantiation.
+	 */
+	private UuidResolverFactory() {}
+	
+	/**
+	 * Creates a new {@link UuidResolver} with the given resource set.
+	 * 
+	 * @param resourceSet is the resource set the UUID resolver uses.
+	 * @return a new {@link UuidResolver} instance.
+	 */
+	public static UuidResolver create(ResourceSet resourceSet) {
+		return new UuidResolverImpl(resourceSet);
+	}
+}

--- a/atomic/src/test/java/tools/vitruv/change/atomic/resolve/internal/AtomicEChangeUnresolver.java
+++ b/atomic/src/test/java/tools/vitruv/change/atomic/resolve/internal/AtomicEChangeUnresolver.java
@@ -7,6 +7,7 @@ import tools.vitruv.change.atomic.EChange;
 import tools.vitruv.change.atomic.resolve.AtomicEChangeResolverHelper;
 import tools.vitruv.change.atomic.uuid.Uuid;
 import tools.vitruv.change.atomic.uuid.UuidResolver;
+import tools.vitruv.change.atomic.uuid.UuidResolverFactory;
 
 /**
  * Utility class to allow unresolving changes that were created using the atomic change factories.
@@ -35,7 +36,7 @@ public class AtomicEChangeUnresolver {
    * @return The unresolving {@link EChange}.
    */
   public EChange<Uuid> unresolve(EChange<? extends EObject> eChange) {
-    UuidResolver temporaryUuidResolver = UuidResolver.create(uuidResolverResourceSet);
+    UuidResolver temporaryUuidResolver = UuidResolverFactory.create(uuidResolverResourceSet);
     return unresolve(eChange, temporaryUuidResolver);
   }
 
@@ -46,7 +47,7 @@ public class AtomicEChangeUnresolver {
    * @return The list of unresolving {@link EChange}s.
    */
   public List<EChange<Uuid>> unresolve(List<? extends EChange<? extends EObject>> eChanges) {
-    UuidResolver temporaryUuidResolver = UuidResolver.create(uuidResolverResourceSet);
+    UuidResolver temporaryUuidResolver = UuidResolverFactory.create(uuidResolverResourceSet);
     return eChanges.stream().map(eChange -> unresolve(eChange, temporaryUuidResolver)).toList();
   }
 

--- a/atomic/src/test/java/tools/vitruv/change/atomic/uuid/MultiResourceSetUuidResolvingTest.java
+++ b/atomic/src/test/java/tools/vitruv/change/atomic/uuid/MultiResourceSetUuidResolvingTest.java
@@ -38,9 +38,9 @@ class MultiResourceSetUuidResolvingTest {
   void setup(@TestProject Path testProjectPath) {
     this.testProjectPath = testProjectPath;
     this.sourceResourceSet = withGlobalFactories(new ResourceSetImpl());
-    this.sourceUuidResolver = UuidResolver.create(sourceResourceSet);
+    this.sourceUuidResolver = UuidResolverFactory.create(sourceResourceSet);
     this.targetResourceSet = withGlobalFactories(new ResourceSetImpl());
-    this.targetUuidResolver = UuidResolver.create(targetResourceSet);
+    this.targetUuidResolver = UuidResolverFactory.create(targetResourceSet);
   }
 
   @ParameterizedTest(name = "{0} resource(s)")

--- a/atomic/src/test/java/tools/vitruv/change/atomic/uuid/UuidResolvingTest.java
+++ b/atomic/src/test/java/tools/vitruv/change/atomic/uuid/UuidResolvingTest.java
@@ -38,7 +38,7 @@ class UuidResolvingTest {
   void setup(@TestProject Path testProjectPath) {
     this.testProjectPath = testProjectPath;
     this.resourceSet = withGlobalFactories(new ResourceSetImpl());
-    this.uuidResolver = UuidResolver.create(resourceSet);
+    this.uuidResolver = UuidResolverFactory.create(resourceSet);
   }
 
   @ParameterizedTest(name = "{0} element(s)")

--- a/atomic/src/test/java/tools/vitruv/change/atomic/uuid/UuidSerializationTest.java
+++ b/atomic/src/test/java/tools/vitruv/change/atomic/uuid/UuidSerializationTest.java
@@ -40,9 +40,9 @@ class UuidSerializationTest {
   void setup(@TestProject Path testProjectPath) {
     this.testProjectPath = testProjectPath;
     this.storeResourceSet = withGlobalFactories(new ResourceSetImpl());
-    this.storeUuidResolver = UuidResolver.create(storeResourceSet);
+    this.storeUuidResolver = UuidResolverFactory.create(storeResourceSet);
     this.loadResourceSet = withGlobalFactories(new ResourceSetImpl());
-    this.loadUuidResolver = UuidResolver.create(loadResourceSet);
+    this.loadUuidResolver = UuidResolverFactory.create(loadResourceSet);
   }
 
   @ParameterizedTest(name = "{0} element(s)")

--- a/atomic/src/test/xtend/tools/vitruv/change/atomic/EChangeTest.xtend
+++ b/atomic/src/test/xtend/tools/vitruv/change/atomic/EChangeTest.xtend
@@ -16,6 +16,7 @@ import tools.vitruv.change.atomic.util.EChangeAssertHelper
 import tools.vitruv.change.atomic.uuid.AtomicEChangeUuidResolver
 import tools.vitruv.change.atomic.uuid.Uuid
 import tools.vitruv.change.atomic.uuid.UuidResolver
+import tools.vitruv.change.atomic.uuid.UuidResolverFactory
 
 import static tools.vitruv.change.testutils.metamodels.AllElementTypesCreators.*
 
@@ -62,7 +63,7 @@ abstract class EChangeTest {
 
 		// Create model
 		resourceSet = new ResourceSetImpl().withGlobalFactories
-		uuidResolver = UuidResolver.create(resourceSet)
+		uuidResolver = UuidResolverFactory.create(resourceSet)
 		atomicChangeResolver = new AtomicEChangeUuidResolver(uuidResolver)
 		resource = resourceSet.createResource(fileUri)
 

--- a/atomic/src/test/xtend/tools/vitruv/change/atomic/feature/FeatureEChangeTest.xtend
+++ b/atomic/src/test/xtend/tools/vitruv/change/atomic/feature/FeatureEChangeTest.xtend
@@ -14,6 +14,7 @@ import tools.vitruv.change.atomic.EChange
 import tools.vitruv.change.atomic.EChangeTest
 import tools.vitruv.change.atomic.uuid.Uuid
 import tools.vitruv.change.atomic.uuid.UuidResolver
+import tools.vitruv.change.atomic.uuid.UuidResolverFactory
 
 import static org.junit.jupiter.api.Assertions.assertNull
 import static org.junit.jupiter.api.Assertions.assertThrows
@@ -41,7 +42,7 @@ class FeatureEChangeTest extends EChangeTest {
 		// Load model in second resource
 		val resourceSet2 = new ResourceSetImpl().withGlobalFactories
 		resource2 = resourceSet2.getResource(resource.URI, true)
-		uuidResolver2 = UuidResolver.create(resourceSet2)
+		uuidResolver2 = UuidResolverFactory.create(resourceSet2)
 		resource2.allContents.forEach[uuidResolver2.registerEObject(it)]
 	}
 

--- a/composite/src/test/xtend/tools/vitruv/change/composite/ChangeDescription2ChangeTransformationTest.xtend
+++ b/composite/src/test/xtend/tools/vitruv/change/composite/ChangeDescription2ChangeTransformationTest.xtend
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.^extension.ExtendWith
 import tools.vitruv.change.atomic.EChange
 import tools.vitruv.change.atomic.uuid.Uuid
 import tools.vitruv.change.atomic.uuid.UuidResolver
+import tools.vitruv.change.atomic.uuid.UuidResolverFactory
 import tools.vitruv.change.composite.description.VitruviusChange
 import tools.vitruv.change.composite.description.VitruviusChangeResolver
 import tools.vitruv.change.composite.description.VitruviusChangeResolverFactory
@@ -51,7 +52,7 @@ abstract class ChangeDescription2ChangeTransformationTest {
 	def void beforeTest(@TestProject Path tempFolder) {
 		this.tempFolder = tempFolder
 		this.resourceSet = new ResourceSetImpl().withGlobalFactories()
-		this.uuidResolver = UuidResolver.create(resourceSet)
+		this.uuidResolver = UuidResolverFactory.create(resourceSet)
 		this.changeRecorder = new ChangeRecorder(resourceSet)
 		this.changeResolver = VitruviusChangeResolverFactory.forUuids(uuidResolver);
 		this.resourceSet.startRecording
@@ -124,7 +125,7 @@ abstract class ChangeDescription2ChangeTransformationTest {
 	private def <T> T validateChange(Function<Consumer<VitruviusChange<Uuid>>, T> operationToValidate) {
 		val comparisonResourceSet = new ResourceSetImpl().withGlobalFactories()
 		val originalToComparisonResourceMapping = resourceSet.copyTo(comparisonResourceSet)
-		val comparisonUuidResolver = UuidResolver.create(comparisonResourceSet)
+		val comparisonUuidResolver = UuidResolverFactory.create(comparisonResourceSet)
 		val comparisonChangeResolver = VitruviusChangeResolverFactory.forUuids(comparisonUuidResolver)
 		uuidResolver.resolveResources(originalToComparisonResourceMapping, comparisonUuidResolver)
 		operationToValidate.apply [ unresolvedChange |

--- a/composite/src/test/xtend/tools/vitruv/change/composite/recording/ChangeRecorderTest.xtend
+++ b/composite/src/test/xtend/tools/vitruv/change/composite/recording/ChangeRecorderTest.xtend
@@ -26,7 +26,6 @@ import tools.vitruv.change.atomic.feature.reference.RemoveEReference
 import tools.vitruv.change.atomic.feature.reference.ReplaceSingleValuedEReference
 import tools.vitruv.change.atomic.root.InsertRootEObject
 import tools.vitruv.change.atomic.root.RemoveRootEObject
-import tools.vitruv.change.atomic.uuid.UuidResolver
 import tools.vitruv.change.atomic.uuid.UuidResolverFactory
 import tools.vitruv.change.composite.description.TransactionalChange
 import tools.vitruv.change.testutils.RegisterMetamodelsInStandalone

--- a/composite/src/test/xtend/tools/vitruv/change/composite/recording/ChangeRecorderTest.xtend
+++ b/composite/src/test/xtend/tools/vitruv/change/composite/recording/ChangeRecorderTest.xtend
@@ -27,6 +27,7 @@ import tools.vitruv.change.atomic.feature.reference.ReplaceSingleValuedEReferenc
 import tools.vitruv.change.atomic.root.InsertRootEObject
 import tools.vitruv.change.atomic.root.RemoveRootEObject
 import tools.vitruv.change.atomic.uuid.UuidResolver
+import tools.vitruv.change.atomic.uuid.UuidResolverFactory
 import tools.vitruv.change.composite.description.TransactionalChange
 import tools.vitruv.change.testutils.RegisterMetamodelsInStandalone
 import tools.vitruv.change.testutils.TestProject
@@ -47,7 +48,7 @@ class ChangeRecorderTest {
 	// this test only covers general behaviour of ChangeRecorder. Whether it always produces correct change sequences
 	// is covered by other tests
 	val ResourceSet resourceSet = new ResourceSetImpl().withGlobalFactories()
-	val uuidResolver = UuidResolver.create(resourceSet)
+	val uuidResolver = UuidResolverFactory.create(resourceSet)
 	val ChangeRecorder changeRecorder = new ChangeRecorder(resourceSet)
 
 	private def <T extends EObject> T wrapIntoRecordedResource(T object) {

--- a/propagation/src/main/java/tools/vitruv/change/propagation/impl/DefaultChangeRecordingModelRepository.java
+++ b/propagation/src/main/java/tools/vitruv/change/propagation/impl/DefaultChangeRecordingModelRepository.java
@@ -19,6 +19,7 @@ import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
 import tools.vitruv.change.atomic.uuid.Uuid;
 import tools.vitruv.change.atomic.uuid.UuidResolver;
+import tools.vitruv.change.atomic.uuid.UuidResolverFactory;
 import tools.vitruv.change.composite.description.TransactionalChange;
 import tools.vitruv.change.composite.description.VitruviusChange;
 import tools.vitruv.change.composite.description.VitruviusChangeResolver;
@@ -66,7 +67,7 @@ public class DefaultChangeRecordingModelRepository
       URI correspondencesURI, Path consistencyMetadataFolder) {
     this.consistencyMetadataFolder = consistencyMetadataFolder;
     this.modelsResourceSet = withGlobalFactories(new ResourceSetImpl());
-    this.uuidResolver = UuidResolver.create(modelsResourceSet);
+    this.uuidResolver = UuidResolverFactory.create(modelsResourceSet);
     this.changeResolver = VitruviusChangeResolverFactory.forUuids(uuidResolver);
     this.correspondenceModel = createPersistableCorrespondenceModel(correspondencesURI);
     this.modelsResourceSet

--- a/testutils/integration/src/main/xtend/tools/vitruv/change/testutils/views/ChangePublishingTestView.xtend
+++ b/testutils/integration/src/main/xtend/tools/vitruv/change/testutils/views/ChangePublishingTestView.xtend
@@ -16,6 +16,7 @@ import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl
 import org.eclipse.xtend.lib.annotations.Delegate
 import tools.vitruv.change.atomic.uuid.Uuid
 import tools.vitruv.change.atomic.uuid.UuidResolver
+import tools.vitruv.change.atomic.uuid.UuidResolverFactory
 import tools.vitruv.change.composite.description.PropagatedChange
 import tools.vitruv.change.composite.description.TransactionalChange
 import tools.vitruv.change.composite.description.VitruviusChangeResolver
@@ -69,7 +70,7 @@ class ChangePublishingTestView implements NonTransactionalTestView {
 		BiConsumer<Resource, UuidResolver> uuidResolution
 	) {
 		this.resourceSet = new ResourceSetImpl().withGlobalFactories()
-		this.uuidResolver = UuidResolver.create(resourceSet)
+		this.uuidResolver = UuidResolverFactory.create(resourceSet)
 		this.modelRepository = changeableModelRepository
 		this.delegate = new BasicTestView(persistenceDirectory, resourceSet, userInteraction, uriMode)
 		this.changeRecorder = new ChangeRecorder(resourceSet)


### PR DESCRIPTION
The new class "UuidResolverFactory" contains the "create"-method for the class "UuidResolverImpl", which was originally located in the interface "UuidResolver". 
This breaks the cyclic dependency between "UuidResolver" and "UuidResolverImpl".