### PR TITLE
Atomic e change copier issues, Add a private constructor to hide the implicit public one

### DIFF
--- a/atomic/src/main/java/tools/vitruv/change/atomic/resolve/AtomicEChangeCopier.java
+++ b/atomic/src/main/java/tools/vitruv/change/atomic/resolve/AtomicEChangeCopier.java
@@ -25,6 +25,11 @@ import tools.vitruv.change.atomic.root.RootFactory;
 
 /** A copier for {@link EChange}s that copies the change to a new type. */
 public class AtomicEChangeCopier {
+    
+  private AtomicEChangeCopier() {
+    throw new UnsupportedOperationException("Utility class should not be instantiated");
+  }
+  
   /**
    * Copy the given change to a new type.
    *
@@ -33,10 +38,6 @@ public class AtomicEChangeCopier {
    * @param change The change to copy.
    * @return The copied change.
    */
-  private AtomicEChangeCopier() {
-    throw new IllegalStateException("Utility class");
-  }
-
   public static <Source, Target> EChange<Target> copy(EChange<Source> change) {
     EChange<Target> result = copyOld(change);
     if (change instanceof EObjectExistenceEChange<Source> existenceChange

--- a/atomic/src/main/java/tools/vitruv/change/atomic/resolve/AtomicEChangeCopier.java
+++ b/atomic/src/main/java/tools/vitruv/change/atomic/resolve/AtomicEChangeCopier.java
@@ -65,9 +65,9 @@ public class AtomicEChangeCopier {
   }
 
   private static <Source, Target> EChange<Target> copyOld(EChange<Source> change) {
-    if (change instanceof InsertRootEObject<Source> c) {
+    if (change instanceof InsertRootEObject<Source>) {
       return RootFactory.eINSTANCE.createInsertRootEObject();
-    } else if (change instanceof RemoveRootEObject<Source> c) {
+    } else if (change instanceof RemoveRootEObject<Source>) {
       return RootFactory.eINSTANCE.createRemoveRootEObject();
     } else if (change instanceof InsertEAttributeValue<Source, ?> c) {
       return getChangeFactory()
@@ -88,9 +88,9 @@ public class AtomicEChangeCopier {
     } else if (change instanceof RemoveEReference<Source> c) {
       return getChangeFactory()
           .createRemoveReferenceChange(null, c.getAffectedFeature(), null, c.getIndex());
-    } else if (change instanceof CreateEObject<Source> c) {
+    } else if (change instanceof CreateEObject<Source>) {
       return EobjectFactory.eINSTANCE.createCreateEObject();
-    } else if (change instanceof DeleteEObject<Source> c) {
+    } else if (change instanceof DeleteEObject<Source>) {
       return EobjectFactory.eINSTANCE.createDeleteEObject();
     } else if (change instanceof UnsetFeature<Source, ?> c) {
       return copyUnsetFeature(c);

--- a/atomic/src/main/java/tools/vitruv/change/atomic/resolve/AtomicEChangeCopier.java
+++ b/atomic/src/main/java/tools/vitruv/change/atomic/resolve/AtomicEChangeCopier.java
@@ -33,6 +33,10 @@ public class AtomicEChangeCopier {
    * @param change The change to copy.
    * @return The copied change.
    */
+  private AtomicEChangeCopier() {
+    throw new IllegalStateException("Utility class");
+  }
+
   public static <Source, Target> EChange<Target> copy(EChange<Source> change) {
     EChange<Target> result = copyOld(change);
     if (change instanceof EObjectExistenceEChange<Source> existenceChange


### PR DESCRIPTION
Solved issues:
https://sonarcloud.io/project/issues?open=AZNj0wNVwOi9Iwmbdg4a&id=vitruv-tools_Vitruv-Change