### PR TITLE
248 add a private constructor to hide the implicit public one

### DIFF
--- a/atomic/pom.xml
+++ b/atomic/pom.xml
@@ -123,5 +123,19 @@
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/atomic/src/main/java/tools/vitruv/change/atomic/message/Error.java
+++ b/atomic/src/main/java/tools/vitruv/change/atomic/message/Error.java
@@ -3,7 +3,10 @@ package tools.vitruv.change.atomic.message;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
+/**
+ * Holds constant error messages for change copying.
+ */
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class Error {
-    public static final String UNKNOWN_CHANGE_OF_TYPE = "trying to copy unknown change of type %s";
+  public static final String UNKNOWN_CHANGE_OF_TYPE = "trying to copy unknown change of type %s";
 }

--- a/atomic/src/main/java/tools/vitruv/change/atomic/message/Error.java
+++ b/atomic/src/main/java/tools/vitruv/change/atomic/message/Error.java
@@ -1,5 +1,9 @@
 package tools.vitruv.change.atomic.message;
 
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class Error {
     public static final String UNKNOWN_CHANGE_OF_TYPE = "trying to copy unknown change of type %s";
 }

--- a/atomic/src/main/java/tools/vitruv/change/atomic/message/Error.java
+++ b/atomic/src/main/java/tools/vitruv/change/atomic/message/Error.java
@@ -4,7 +4,7 @@ import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
 /**
- * Holds constant error messages for change copying.
+ * Holds constant error messages.
  */
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class Error {

--- a/atomic/src/main/java/tools/vitruv/change/atomic/message/Error.java
+++ b/atomic/src/main/java/tools/vitruv/change/atomic/message/Error.java
@@ -1,0 +1,5 @@
+package tools.vitruv.change.atomic.message;
+
+public class Error {
+    public static final String UNKNOWN_CHANGE_OF_TYPE = "trying to copy unknown change of type %s";
+}

--- a/atomic/src/main/java/tools/vitruv/change/atomic/resolve/AtomicEChangeCopier.java
+++ b/atomic/src/main/java/tools/vitruv/change/atomic/resolve/AtomicEChangeCopier.java
@@ -23,6 +23,8 @@ import tools.vitruv.change.atomic.root.RemoveRootEObject;
 import tools.vitruv.change.atomic.root.RootEChange;
 import tools.vitruv.change.atomic.root.RootFactory;
 
+import static tools.vitruv.change.atomic.message.Error.UNKNOWN_CHANGE_OF_TYPE;
+
 /** A copier for {@link EChange}s that copies the change to a new type. */
 public class AtomicEChangeCopier {
   /**
@@ -61,38 +63,44 @@ public class AtomicEChangeCopier {
   }
 
   private static <Source, Target> EChange<Target> copyOld(EChange<Source> change) {
-    if (change instanceof InsertRootEObject<Source> c) {
+    if (change instanceof InsertRootEObject<Source>) {
       return RootFactory.eINSTANCE.createInsertRootEObject();
-    } else if (change instanceof RemoveRootEObject<Source> c) {
+    } else if (change instanceof RemoveRootEObject<Source>) {
       return RootFactory.eINSTANCE.createRemoveRootEObject();
-    } else if (change instanceof InsertEAttributeValue<Source, ?> c) {
+    } else if (change instanceof InsertEAttributeValue<Source, ?> sourceInsertEAttributeValue) {
       return getChangeFactory()
-          .createInsertAttributeChange(null, c.getAffectedFeature(), c.getIndex(), c.getNewValue());
-    } else if (change instanceof ReplaceSingleValuedEAttribute<Source, ?> c) {
+          .createInsertAttributeChange(null, sourceInsertEAttributeValue.getAffectedFeature(),
+                  sourceInsertEAttributeValue.getIndex(), sourceInsertEAttributeValue.getNewValue());
+    } else if (change instanceof ReplaceSingleValuedEAttribute<Source, ?> sourceReplaceSingleValuedEAttribute) {
       return getChangeFactory()
           .createReplaceSingleAttributeChange(
-              null, c.getAffectedFeature(), c.getOldValue(), c.getNewValue());
-    } else if (change instanceof RemoveEAttributeValue<Source, ?> c) {
+              null, sourceReplaceSingleValuedEAttribute.getAffectedFeature(),
+                  sourceReplaceSingleValuedEAttribute.getOldValue(), sourceReplaceSingleValuedEAttribute.getNewValue());
+    } else if (change instanceof RemoveEAttributeValue<Source, ?> sourceRemoveEAttributeValue) {
       return getChangeFactory()
-          .createRemoveAttributeChange(null, c.getAffectedFeature(), c.getIndex(), c.getOldValue());
-    } else if (change instanceof InsertEReference<Source> c) {
+          .createRemoveAttributeChange(null, sourceRemoveEAttributeValue.getAffectedFeature(),
+                  sourceRemoveEAttributeValue.getIndex(), sourceRemoveEAttributeValue.getOldValue());
+    } else if (change instanceof InsertEReference<Source> sourceInsertEReference) {
       return getChangeFactory()
-          .createInsertReferenceChange(null, c.getAffectedFeature(), null, c.getIndex());
-    } else if (change instanceof ReplaceSingleValuedEReference<Source> c) {
+          .createInsertReferenceChange(null, sourceInsertEReference.getAffectedFeature(),
+                  null, sourceInsertEReference.getIndex());
+    } else if (change instanceof ReplaceSingleValuedEReference<Source> sourceReplaceSingleValuedEReference) {
       return getChangeFactory()
-          .createReplaceSingleReferenceChange(null, c.getAffectedFeature(), null, null);
-    } else if (change instanceof RemoveEReference<Source> c) {
+          .createReplaceSingleReferenceChange(null,
+                  sourceReplaceSingleValuedEReference.getAffectedFeature(),
+                  null, null);
+    } else if (change instanceof RemoveEReference<Source> sourceRemoveEReference) {
       return getChangeFactory()
-          .createRemoveReferenceChange(null, c.getAffectedFeature(), null, c.getIndex());
-    } else if (change instanceof CreateEObject<Source> c) {
+          .createRemoveReferenceChange(null, sourceRemoveEReference.getAffectedFeature(),
+                  null, sourceRemoveEReference.getIndex());
+    } else if (change instanceof CreateEObject<Source>) {
       return EobjectFactory.eINSTANCE.createCreateEObject();
-    } else if (change instanceof DeleteEObject<Source> c) {
+    } else if (change instanceof DeleteEObject<Source>) {
       return EobjectFactory.eINSTANCE.createDeleteEObject();
-    } else if (change instanceof UnsetFeature<Source, ?> c) {
-      return copyUnsetFeature(c);
+    } else if (change instanceof UnsetFeature<Source, ?> sourceUnsetFeature) {
+      return copyUnsetFeature(sourceUnsetFeature);
     }
-    throw new IllegalStateException(
-        "trying to copy unknown change of type " + change.getClass().getSimpleName());
+    throw new IllegalStateException(String.format(UNKNOWN_CHANGE_OF_TYPE, change.getClass().getSimpleName()));
   }
 
   private static TypeInferringAtomicEChangeFactory getChangeFactory() {

--- a/atomic/src/main/java/tools/vitruv/change/atomic/resolve/AtomicEChangeCopier.java
+++ b/atomic/src/main/java/tools/vitruv/change/atomic/resolve/AtomicEChangeCopier.java
@@ -1,5 +1,7 @@
 package tools.vitruv.change.atomic.resolve;
 
+import static tools.vitruv.change.atomic.message.Error.UNKNOWN_CHANGE_OF_TYPE;
+
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.eclipse.emf.ecore.EStructuralFeature;
@@ -24,7 +26,7 @@ import tools.vitruv.change.atomic.root.InsertRootEObject;
 import tools.vitruv.change.atomic.root.RemoveRootEObject;
 import tools.vitruv.change.atomic.root.RootEChange;
 import tools.vitruv.change.atomic.root.RootFactory;
-import static tools.vitruv.change.atomic.message.Error.UNKNOWN_CHANGE_OF_TYPE;
+
 
 /** A copier for {@link EChange}s that copies the change to a new type. */
 @NoArgsConstructor(access = AccessLevel.PRIVATE)

--- a/atomic/src/main/java/tools/vitruv/change/atomic/resolve/AtomicEChangeCopier.java
+++ b/atomic/src/main/java/tools/vitruv/change/atomic/resolve/AtomicEChangeCopier.java
@@ -24,7 +24,6 @@ import tools.vitruv.change.atomic.root.InsertRootEObject;
 import tools.vitruv.change.atomic.root.RemoveRootEObject;
 import tools.vitruv.change.atomic.root.RootEChange;
 import tools.vitruv.change.atomic.root.RootFactory;
-
 import static tools.vitruv.change.atomic.message.Error.UNKNOWN_CHANGE_OF_TYPE;
 
 /** A copier for {@link EChange}s that copies the change to a new type. */
@@ -72,30 +71,45 @@ public class AtomicEChangeCopier {
       return RootFactory.eINSTANCE.createRemoveRootEObject();
     } else if (change instanceof InsertEAttributeValue<Source, ?> sourceInsertEAttributeValue) {
       return getChangeFactory()
-          .createInsertAttributeChange(null, sourceInsertEAttributeValue.getAffectedFeature(),
-                  sourceInsertEAttributeValue.getIndex(), sourceInsertEAttributeValue.getNewValue());
-    } else if (change instanceof ReplaceSingleValuedEAttribute<Source, ?> sourceReplaceSingleValuedEAttribute) {
+          .createInsertAttributeChange(
+              null,
+              sourceInsertEAttributeValue.getAffectedFeature(),
+              sourceInsertEAttributeValue.getIndex(),
+              sourceInsertEAttributeValue.getNewValue());
+    } else if (change
+        instanceof ReplaceSingleValuedEAttribute<Source, ?> sourceReplaceSingleValuedEAttribute) {
       return getChangeFactory()
           .createReplaceSingleAttributeChange(
-              null, sourceReplaceSingleValuedEAttribute.getAffectedFeature(),
-                  sourceReplaceSingleValuedEAttribute.getOldValue(), sourceReplaceSingleValuedEAttribute.getNewValue());
+              null,
+              sourceReplaceSingleValuedEAttribute.getAffectedFeature(),
+              sourceReplaceSingleValuedEAttribute.getOldValue(),
+              sourceReplaceSingleValuedEAttribute.getNewValue());
     } else if (change instanceof RemoveEAttributeValue<Source, ?> sourceRemoveEAttributeValue) {
       return getChangeFactory()
-          .createRemoveAttributeChange(null, sourceRemoveEAttributeValue.getAffectedFeature(),
-                  sourceRemoveEAttributeValue.getIndex(), sourceRemoveEAttributeValue.getOldValue());
+          .createRemoveAttributeChange(
+              null,
+              sourceRemoveEAttributeValue.getAffectedFeature(),
+              sourceRemoveEAttributeValue.getIndex(),
+              sourceRemoveEAttributeValue.getOldValue());
     } else if (change instanceof InsertEReference<Source> sourceInsertEReference) {
       return getChangeFactory()
-          .createInsertReferenceChange(null, sourceInsertEReference.getAffectedFeature(),
-                  null, sourceInsertEReference.getIndex());
-    } else if (change instanceof ReplaceSingleValuedEReference<Source> sourceReplaceSingleValuedEReference) {
+          .createInsertReferenceChange(
+              null,
+              sourceInsertEReference.getAffectedFeature(),
+              null,
+              sourceInsertEReference.getIndex());
+    } else if (change
+        instanceof ReplaceSingleValuedEReference<Source> sourceReplaceSingleValuedEReference) {
       return getChangeFactory()
-          .createReplaceSingleReferenceChange(null,
-                  sourceReplaceSingleValuedEReference.getAffectedFeature(),
-                  null, null);
+          .createReplaceSingleReferenceChange(
+              null, sourceReplaceSingleValuedEReference.getAffectedFeature(), null, null);
     } else if (change instanceof RemoveEReference<Source> sourceRemoveEReference) {
       return getChangeFactory()
-          .createRemoveReferenceChange(null, sourceRemoveEReference.getAffectedFeature(),
-                  null, sourceRemoveEReference.getIndex());
+          .createRemoveReferenceChange(
+              null,
+              sourceRemoveEReference.getAffectedFeature(),
+              null,
+              sourceRemoveEReference.getIndex());
     } else if (change instanceof CreateEObject<Source>) {
       return EobjectFactory.eINSTANCE.createCreateEObject();
     } else if (change instanceof DeleteEObject<Source>) {
@@ -103,7 +117,8 @@ public class AtomicEChangeCopier {
     } else if (change instanceof UnsetFeature<Source, ?> sourceUnsetFeature) {
       return copyUnsetFeature(sourceUnsetFeature);
     }
-    throw new IllegalStateException(String.format(UNKNOWN_CHANGE_OF_TYPE, change.getClass().getSimpleName()));
+    throw new IllegalStateException(
+        String.format(UNKNOWN_CHANGE_OF_TYPE, change.getClass().getSimpleName()));
   }
 
   private static TypeInferringAtomicEChangeFactory getChangeFactory() {

--- a/atomic/src/main/java/tools/vitruv/change/atomic/resolve/AtomicEChangeCopier.java
+++ b/atomic/src/main/java/tools/vitruv/change/atomic/resolve/AtomicEChangeCopier.java
@@ -1,5 +1,7 @@
 package tools.vitruv.change.atomic.resolve;
 
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 import org.eclipse.emf.ecore.EStructuralFeature;
 import tools.vitruv.change.atomic.EChange;
 import tools.vitruv.change.atomic.TypeInferringAtomicEChangeFactory;
@@ -26,6 +28,7 @@ import tools.vitruv.change.atomic.root.RootFactory;
 import static tools.vitruv.change.atomic.message.Error.UNKNOWN_CHANGE_OF_TYPE;
 
 /** A copier for {@link EChange}s that copies the change to a new type. */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class AtomicEChangeCopier {
   /**
    * Copy the given change to a new type.

--- a/atomic/src/test/java/tools/vitruv/change/atomic/resolve/AtomicEChangeCopierUnitTest.java
+++ b/atomic/src/test/java/tools/vitruv/change/atomic/resolve/AtomicEChangeCopierUnitTest.java
@@ -1,5 +1,10 @@
 package tools.vitruv.change.atomic.resolve;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static tools.vitruv.change.atomic.message.Error.UNKNOWN_CHANGE_OF_TYPE;
+
 import org.eclipse.emf.ecore.EAttribute;
 import org.eclipse.emf.ecore.EReference;
 import org.eclipse.emf.ecore.EStructuralFeature;
@@ -21,11 +26,6 @@ import tools.vitruv.change.atomic.feature.single.ReplaceSingleValuedFeatureEChan
 import tools.vitruv.change.atomic.root.InsertRootEObject;
 import tools.vitruv.change.atomic.root.RemoveRootEObject;
 import tools.vitruv.change.atomic.root.RootFactory;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
-import static org.mockito.Mockito.mock;
-import static tools.vitruv.change.atomic.message.Error.UNKNOWN_CHANGE_OF_TYPE;
 
 class AtomicEChangeCopierUnitTest {
 

--- a/atomic/src/test/java/tools/vitruv/change/atomic/resolve/AtomicEChangeCopierUnitTest.java
+++ b/atomic/src/test/java/tools/vitruv/change/atomic/resolve/AtomicEChangeCopierUnitTest.java
@@ -31,12 +31,11 @@ class AtomicEChangeCopierUnitTest {
 
   @Test
   void constructor_isPrivate() throws Exception {
-    Constructor<AtomicEChangeCopier> constructor =
-        AtomicEChangeCopier.class.getDeclaredConstructor();
+    var constructor = AtomicEChangeCopier.class.getDeclaredConstructor();
     assertThat(constructor.canAccess(null)).isFalse();
 
     constructor.setAccessible(true);
-    AtomicEChangeCopier instance = constructor.newInstance();
+    var instance = constructor.newInstance();
     assertThat(instance).isNotNull();
   }
 

--- a/atomic/src/test/java/tools/vitruv/change/atomic/resolve/AtomicEChangeCopierUnitTest.java
+++ b/atomic/src/test/java/tools/vitruv/change/atomic/resolve/AtomicEChangeCopierUnitTest.java
@@ -1,0 +1,206 @@
+package tools.vitruv.change.atomic.resolve;
+
+import org.eclipse.emf.ecore.*;
+import org.junit.jupiter.api.Test;
+import tools.vitruv.change.atomic.EChange;
+import tools.vitruv.change.atomic.TypeInferringAtomicEChangeFactory;
+import tools.vitruv.change.atomic.eobject.CreateEObject;
+import tools.vitruv.change.atomic.eobject.DeleteEObject;
+import tools.vitruv.change.atomic.eobject.EobjectFactory;
+import tools.vitruv.change.atomic.feature.FeatureFactory;
+import tools.vitruv.change.atomic.feature.UnsetFeature;
+import tools.vitruv.change.atomic.feature.attribute.InsertEAttributeValue;
+import tools.vitruv.change.atomic.feature.attribute.RemoveEAttributeValue;
+import tools.vitruv.change.atomic.feature.attribute.ReplaceSingleValuedEAttribute;
+import tools.vitruv.change.atomic.feature.reference.InsertEReference;
+import tools.vitruv.change.atomic.feature.reference.RemoveEReference;
+import tools.vitruv.change.atomic.feature.reference.ReplaceSingleValuedEReference;
+import tools.vitruv.change.atomic.feature.single.ReplaceSingleValuedFeatureEChange;
+import tools.vitruv.change.atomic.root.InsertRootEObject;
+import tools.vitruv.change.atomic.root.RemoveRootEObject;
+import tools.vitruv.change.atomic.root.RootFactory;
+
+import java.lang.reflect.Constructor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static tools.vitruv.change.atomic.message.Error.UNKNOWN_CHANGE_OF_TYPE;
+
+class AtomicEChangeCopierUnitTest {
+
+  @Test
+  void constructor_isPrivate() throws Exception {
+    Constructor<AtomicEChangeCopier> constructor =
+        AtomicEChangeCopier.class.getDeclaredConstructor();
+    assertThat(constructor.canAccess(null)).isFalse();
+
+    constructor.setAccessible(true);
+    AtomicEChangeCopier instance = constructor.newInstance();
+    assertThat(instance).isNotNull();
+  }
+
+  @Test
+  void testCopy_InsertRootEObject() {
+    var original = RootFactory.eINSTANCE.createInsertRootEObject();
+    original.setUri("test://insert");
+    original.setIndex(42);
+
+    var copy = AtomicEChangeCopier.copy(original);
+
+    assertThat(copy).isInstanceOf(InsertRootEObject.class);
+    var insertCopy = (InsertRootEObject<?>) copy;
+    assertThat(insertCopy.getUri()).isEqualTo("test://insert");
+    assertThat(insertCopy.getIndex()).isEqualTo(42);
+  }
+
+  @Test
+  void testCopy_RemoveRootEObject() {
+    var original = RootFactory.eINSTANCE.createRemoveRootEObject();
+    original.setUri("test://remove");
+    original.setIndex(24);
+
+    var copy = AtomicEChangeCopier.copy(original);
+
+    assertThat(copy).isInstanceOf(RemoveRootEObject.class);
+    var removeCopy = (RemoveRootEObject<?>) copy;
+    assertThat(removeCopy.getUri()).isEqualTo("test://remove");
+    assertThat(removeCopy.getIndex()).isEqualTo(24);
+  }
+
+  @Test
+  void testCopy_CreateEObject() {
+    var original = EobjectFactory.eINSTANCE.createCreateEObject();
+
+    var copy = AtomicEChangeCopier.copy(original);
+
+    assertThat(copy).isInstanceOf(CreateEObject.class);
+  }
+
+  @Test
+  void testCopy_DeleteEObject() {
+    var original = EobjectFactory.eINSTANCE.createDeleteEObject();
+
+    var copy = AtomicEChangeCopier.copy(original);
+
+    assertThat(copy).isInstanceOf(DeleteEObject.class);
+  }
+
+  @Test
+  void testCopy_UnsetFeature() {
+    var feature = mock(EStructuralFeature.class);
+
+    var original = FeatureFactory.eINSTANCE.createUnsetFeature();
+    original.setAffectedFeature(feature);
+
+    var copy = AtomicEChangeCopier.copy(original);
+
+    assertThat(copy).isInstanceOf(UnsetFeature.class);
+    var unsetCopy = (UnsetFeature<?, ?>) copy;
+    assertThat(unsetCopy.getAffectedFeature()).isEqualTo(feature);
+  }
+
+  @Test
+  void testCopy_InsertEAttributeValue() {
+    var feature = mock(EAttribute.class);
+
+    var original =
+        TypeInferringAtomicEChangeFactory.getInstance()
+            .createInsertAttributeChange(null, feature, 1, "newVal");
+
+    var copy = AtomicEChangeCopier.copy(original);
+
+    assertThat(copy).isInstanceOf(InsertEAttributeValue.class);
+    var insertCopy = (InsertEAttributeValue<?, ?>) copy;
+    assertThat(insertCopy.getIndex()).isEqualTo(1);
+    assertThat(insertCopy.getNewValue()).isEqualTo("newVal");
+  }
+
+  @Test
+  void testCopy_ReplaceSingleValuedEAttribute() {
+    var feature = mock(EAttribute.class);
+
+    var original =
+        TypeInferringAtomicEChangeFactory.getInstance()
+            .createReplaceSingleAttributeChange(null, feature, "oldVal", "newVal");
+    original.setIsUnset(true);
+
+    var copy = AtomicEChangeCopier.copy(original);
+
+    assertThat(copy).isInstanceOf(ReplaceSingleValuedEAttribute.class);
+    var replaceCopy = (ReplaceSingleValuedFeatureEChange<?, ?, ?>) copy;
+    assertThat(replaceCopy.isIsUnset()).isTrue();
+  }
+
+  @Test
+  void testCopy_RemoveEAttributeValue() {
+    var feature = mock(EAttribute.class);
+
+    var original =
+        TypeInferringAtomicEChangeFactory.getInstance()
+            .createRemoveAttributeChange(null, feature, 2, "oldVal");
+
+    var copy = AtomicEChangeCopier.copy(original);
+
+    assertThat(copy).isInstanceOf(RemoveEAttributeValue.class);
+    var removeCopy = (RemoveEAttributeValue<?, ?>) copy;
+    assertThat(removeCopy.getIndex()).isEqualTo(2);
+    assertThat(removeCopy.getOldValue()).isEqualTo("oldVal");
+  }
+
+  @Test
+  void testCopy_InsertEReference() {
+    var feature = mock(EReference.class);
+
+    var original =
+        TypeInferringAtomicEChangeFactory.getInstance()
+            .createInsertReferenceChange(null, feature, null, 3);
+
+    var copy = AtomicEChangeCopier.copy(original);
+
+    assertThat(copy).isInstanceOf(InsertEReference.class);
+    var insertRefCopy = (InsertEReference<?>) copy;
+    assertThat(insertRefCopy.getIndex()).isEqualTo(3);
+  }
+
+  @Test
+  void testCopy_ReplaceSingleValuedEReference() {
+    var feature = mock(EReference.class);
+
+    var original =
+        TypeInferringAtomicEChangeFactory.getInstance()
+            .createReplaceSingleReferenceChange(null, feature, null, null);
+    original.setIsUnset(true);
+
+    var copy = AtomicEChangeCopier.copy(original);
+
+    assertThat(copy).isInstanceOf(ReplaceSingleValuedEReference.class);
+    var replaceCopy = (ReplaceSingleValuedFeatureEChange<?, ?, ?>) copy;
+    assertThat(replaceCopy.isIsUnset()).isTrue();
+  }
+
+  @Test
+  void testCopy_RemoveEReference() {
+    var feature = mock(EReference.class);
+
+    var original =
+        TypeInferringAtomicEChangeFactory.getInstance()
+            .createRemoveReferenceChange(null, feature, null, 4);
+
+    var copy = AtomicEChangeCopier.copy(original);
+
+    assertThat(copy).isInstanceOf(RemoveEReference.class);
+    var removeRefCopy = (RemoveEReference<?>) copy;
+    assertThat(removeRefCopy.getIndex()).isEqualTo(4);
+  }
+
+  @Test
+  void testCopy_UnknownType_ThrowsException() {
+    @SuppressWarnings("unchecked")
+    EChange<Object> unknown = mock(EChange.class);
+
+    assertThatThrownBy(() -> AtomicEChangeCopier.copy(unknown))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining(String.format(UNKNOWN_CHANGE_OF_TYPE, ""));
+  }
+}

--- a/atomic/src/test/java/tools/vitruv/change/atomic/resolve/AtomicEChangeCopierUnitTest.java
+++ b/atomic/src/test/java/tools/vitruv/change/atomic/resolve/AtomicEChangeCopierUnitTest.java
@@ -1,6 +1,8 @@
 package tools.vitruv.change.atomic.resolve;
 
-import org.eclipse.emf.ecore.*;
+import org.eclipse.emf.ecore.EAttribute;
+import org.eclipse.emf.ecore.EReference;
+import org.eclipse.emf.ecore.EStructuralFeature;
 import org.junit.jupiter.api.Test;
 import tools.vitruv.change.atomic.EChange;
 import tools.vitruv.change.atomic.TypeInferringAtomicEChangeFactory;
@@ -19,8 +21,6 @@ import tools.vitruv.change.atomic.feature.single.ReplaceSingleValuedFeatureEChan
 import tools.vitruv.change.atomic.root.InsertRootEObject;
 import tools.vitruv.change.atomic.root.RemoveRootEObject;
 import tools.vitruv.change.atomic.root.RootFactory;
-
-import java.lang.reflect.Constructor;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;

--- a/atomic/src/test/java/tools/vitruv/change/atomic/resolve/AtomicEChangeCopierUnitTest.java
+++ b/atomic/src/test/java/tools/vitruv/change/atomic/resolve/AtomicEChangeCopierUnitTest.java
@@ -30,7 +30,7 @@ import static tools.vitruv.change.atomic.message.Error.UNKNOWN_CHANGE_OF_TYPE;
 class AtomicEChangeCopierUnitTest {
 
   @Test
-  void constructor_isPrivate() throws Exception {
+  void constructorIsPrivate() throws Exception {
     var constructor = AtomicEChangeCopier.class.getDeclaredConstructor();
     assertThat(constructor.canAccess(null)).isFalse();
 
@@ -40,7 +40,7 @@ class AtomicEChangeCopierUnitTest {
   }
 
   @Test
-  void testCopy_InsertRootEObject() {
+  void testCopyInsertRootEObject() {
     var original = RootFactory.eINSTANCE.createInsertRootEObject();
     original.setUri("test://insert");
     original.setIndex(42);
@@ -54,7 +54,7 @@ class AtomicEChangeCopierUnitTest {
   }
 
   @Test
-  void testCopy_RemoveRootEObject() {
+  void testCopyRemoveRootEObject() {
     var original = RootFactory.eINSTANCE.createRemoveRootEObject();
     original.setUri("test://remove");
     original.setIndex(24);
@@ -68,7 +68,7 @@ class AtomicEChangeCopierUnitTest {
   }
 
   @Test
-  void testCopy_CreateEObject() {
+  void testCopyCreateEObject() {
     var original = EobjectFactory.eINSTANCE.createCreateEObject();
 
     var copy = AtomicEChangeCopier.copy(original);
@@ -77,7 +77,7 @@ class AtomicEChangeCopierUnitTest {
   }
 
   @Test
-  void testCopy_DeleteEObject() {
+  void testCopyDeleteEObject() {
     var original = EobjectFactory.eINSTANCE.createDeleteEObject();
 
     var copy = AtomicEChangeCopier.copy(original);
@@ -86,7 +86,7 @@ class AtomicEChangeCopierUnitTest {
   }
 
   @Test
-  void testCopy_UnsetFeature() {
+  void testCopyUnsetFeature() {
     var feature = mock(EStructuralFeature.class);
 
     var original = FeatureFactory.eINSTANCE.createUnsetFeature();
@@ -100,7 +100,7 @@ class AtomicEChangeCopierUnitTest {
   }
 
   @Test
-  void testCopy_InsertEAttributeValue() {
+  void testCopyInsertEAttributeValue() {
     var feature = mock(EAttribute.class);
 
     var original =
@@ -116,7 +116,7 @@ class AtomicEChangeCopierUnitTest {
   }
 
   @Test
-  void testCopy_ReplaceSingleValuedEAttribute() {
+  void testCopyReplaceSingleValuedEAttribute() {
     var feature = mock(EAttribute.class);
 
     var original =
@@ -132,7 +132,7 @@ class AtomicEChangeCopierUnitTest {
   }
 
   @Test
-  void testCopy_RemoveEAttributeValue() {
+  void testCopyRemoveEAttributeValue() {
     var feature = mock(EAttribute.class);
 
     var original =
@@ -148,7 +148,7 @@ class AtomicEChangeCopierUnitTest {
   }
 
   @Test
-  void testCopy_InsertEReference() {
+  void testCopyInsertEReference() {
     var feature = mock(EReference.class);
 
     var original =
@@ -163,7 +163,7 @@ class AtomicEChangeCopierUnitTest {
   }
 
   @Test
-  void testCopy_ReplaceSingleValuedEReference() {
+  void testCopyReplaceSingleValuedEReference() {
     var feature = mock(EReference.class);
 
     var original =
@@ -179,7 +179,7 @@ class AtomicEChangeCopierUnitTest {
   }
 
   @Test
-  void testCopy_RemoveEReference() {
+  void testCopyRemoveEReference() {
     var feature = mock(EReference.class);
 
     var original =
@@ -194,7 +194,7 @@ class AtomicEChangeCopierUnitTest {
   }
 
   @Test
-  void testCopy_UnknownType_ThrowsException() {
+  void testCopyUnknownTypeThrowsException() {
     @SuppressWarnings("unchecked")
     EChange<Object> unknown = mock(EChange.class);
 

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,12 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-core</artifactId>
+        <version>5.17.0</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
         <groupId>org.assertj</groupId>
         <artifactId>assertj-core</artifactId>
         <version>3.27.3</version>


### PR DESCRIPTION
resolved private constructor to hide the implicit public one issues from sonar cloud 
added test cases for AtomicEChangeCopier.class