### PR TITLE
Fix Maven Central Deployment Problems

### DIFF
--- a/atomic/pom.xml
+++ b/atomic/pom.xml
@@ -14,7 +14,9 @@
   <artifactId>tools.vitruv.change.atomic</artifactId>
 
   <name>Vitruv Atomic Change Metamodel</name>
-  <description />
+  <description>
+    Metamodel, Resolution and Application of Atomic Changes
+  </description>
 
   <build>
     <plugins>

--- a/changederivation/pom.xml
+++ b/changederivation/pom.xml
@@ -14,7 +14,7 @@
   <artifactId>tools.vitruv.change.changederivation</artifactId>
 
   <name>Vitruv Change Derivation</name>
-  <description />
+  <description>Derivation and Persistence of Model Deltas from Model States.</description> 
 
   <build>
     <plugins>

--- a/composite/pom.xml
+++ b/composite/pom.xml
@@ -14,7 +14,7 @@
   <artifactId>tools.vitruv.change.composite</artifactId>
 
   <name>Vitruv Composite Change Metamodel</name>
-  <description />
+  <description>Description, Recording, and Propagation of Composite Changes on V-SUMs.</description>
 
   <build>
     <plugins>

--- a/correspondence/pom.xml
+++ b/correspondence/pom.xml
@@ -14,7 +14,9 @@
   <artifactId>tools.vitruv.change.correspondence</artifactId>
 
   <name>Vitruv Correspondence Metamodel</name>
-  <description />
+  <description>
+    Management of Correspondences between Pairs of Model Elements across Different Models.
+  </description>
 
   <build>
     <plugins>

--- a/interaction.model/pom.xml
+++ b/interaction.model/pom.xml
@@ -14,7 +14,7 @@
   <artifactId>tools.vitruv.change.interaction.model</artifactId>
 
   <name>Vitruv Change Interactions Metamodel</name>
-  <description />
+  <description>Metamodel for Representing User Inputs during Change Propagation.</description>
 
   <build>
     <plugins>

--- a/interaction/pom.xml
+++ b/interaction/pom.xml
@@ -14,7 +14,7 @@
   <artifactId>tools.vitruv.change.interaction</artifactId>
 
   <name>Vitruv Change Interactions</name>
-  <description />
+  <description>Tooling for Requesting User Input during Change Propagation.</description>
 
   <build>
     <plugins>

--- a/p2wrappers/pom.xml
+++ b/p2wrappers/pom.xml
@@ -15,7 +15,7 @@
   <packaging>pom</packaging>
 
   <name>p2 Dependency Wrappers</name>
-  <description />
+  <description>Wrappers for p2 dependencies.</description>
 
   <modules>
     <module>activextendannotations</module>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>tools.vitruv</groupId>
     <artifactId>parent</artifactId>
-    <version>3.2.2</version>
+    <version>3.3.0</version>
   </parent>
 
   <!-- Project Information -->

--- a/propagation/pom.xml
+++ b/propagation/pom.xml
@@ -14,7 +14,7 @@
   <artifactId>tools.vitruv.change.propagation</artifactId>
 
   <name>Vitruv Framework Change Processing</name>
-  <description />
+  <description>Propagation of Changes across Multiple Models according to Abstract Change Propagation Specifications.</description>
 
   <build>
     <plugins>

--- a/testutils/core/pom.xml
+++ b/testutils/core/pom.xml
@@ -14,7 +14,7 @@
   <artifactId>tools.vitruv.change.testutils.core</artifactId>
 
   <name>Vitruv Change Test Utilities Core</name>
-  <description />
+  <description>Common Utilities for Defining Tests using Change and Propagation Specifications.</description>
 
   <build>
     <plugins>

--- a/testutils/integration/pom.xml
+++ b/testutils/integration/pom.xml
@@ -14,7 +14,7 @@
   <artifactId>tools.vitruv.change.testutils.integration</artifactId>
 
   <name>Vitruv Change Test Utilities for Integration</name>
-  <description />
+  <description>Testing Views and User Interaction Testing.</description>
 
   <build>
     <plugins>

--- a/testutils/metamodels/pom.xml
+++ b/testutils/metamodels/pom.xml
@@ -14,7 +14,7 @@
   <artifactId>tools.vitruv.change.testutils.metamodels</artifactId>
 
   <name>Vitruv Change Test Utilities Metamodels</name>
-  <description />
+  <description>Metamodels used in Testing Vitruv Change and Propagation Specifications.</description>
 
   <build>
     <plugins>

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -14,7 +14,7 @@
   <artifactId>tools.vitruv.change.utils</artifactId>
 
   <name>Vitruv Change Utilities</name>
-  <description />
+  <description>Common Utilities used across Modules in Vitruv-Change.</description>
 
   <build>
     <plugins>


### PR DESCRIPTION
- [x] Adds missing descriptions for Maven modules/subprojects.
- [x] Updates the Maven-Build-Parent to Version 3.3.0, to fix Javadoc generation.