### PR TITLE
Reduce cognitive complexity of the postprocessRemovals method

### DIFF
--- a/composite/src/main/java/tools/vitruv/change/composite/description/impl/TransactionalChangeImpl.java
+++ b/composite/src/main/java/tools/vitruv/change/composite/description/impl/TransactionalChangeImpl.java
@@ -62,29 +62,29 @@ public class TransactionalChangeImpl<Element extends Object> implements Transact
     URI _switchResult = null;
     boolean _matched = false;
     if (eChange instanceof FeatureEChange) {
-      _matched=true;
-      EObject _affectedElement = ((FeatureEChange<EObject, ?>)eChange).getAffectedElement();
+      _matched = true;
+      EObject _affectedElement = ((FeatureEChange<EObject, ?>) eChange).getAffectedElement();
       URI _objectUri = null;
-      if (_affectedElement!=null) {
-        _objectUri=TransactionalChangeImpl.getObjectUri(_affectedElement);
+      if (_affectedElement != null) {
+        _objectUri = TransactionalChangeImpl.getObjectUri(_affectedElement);
       }
       _switchResult = _objectUri;
     }
     if (!_matched) {
       if (eChange instanceof EObjectExistenceEChange) {
-        _matched=true;
-        EObject _affectedElement = ((EObjectExistenceEChange<EObject>)eChange).getAffectedElement();
+        _matched = true;
+        EObject _affectedElement = ((EObjectExistenceEChange<EObject>) eChange).getAffectedElement();
         URI _objectUri = null;
-        if (_affectedElement!=null) {
-          _objectUri=TransactionalChangeImpl.getObjectUri(_affectedElement);
+        if (_affectedElement != null) {
+          _objectUri = TransactionalChangeImpl.getObjectUri(_affectedElement);
         }
         _switchResult = _objectUri;
       }
     }
     if (!_matched) {
       if (eChange instanceof RootEChange) {
-        _matched=true;
-        _switchResult = URI.createURI(((RootEChange<?>)eChange).getUri());
+        _matched = true;
+        _switchResult = URI.createURI(((RootEChange<?>) eChange).getUri());
       }
     }
     return _switchResult;
@@ -133,25 +133,25 @@ public class TransactionalChangeImpl<Element extends Object> implements Transact
     Set<EObject> _switchResult = null;
     boolean _matched = false;
     if (eChange instanceof FeatureEChange) {
-      _matched=true;
-      _switchResult = Set.<EObject>of(((FeatureEChange<EObject, ?>)eChange).getAffectedElement());
+      _matched = true;
+      _switchResult = Set.<EObject>of(((FeatureEChange<EObject, ?>) eChange).getAffectedElement());
     }
     if (!_matched) {
       if (eChange instanceof EObjectExistenceEChange) {
-        _matched=true;
-        _switchResult = Set.<EObject>of(((EObjectExistenceEChange<EObject>)eChange).getAffectedElement());
+        _matched = true;
+        _switchResult = Set.<EObject>of(((EObjectExistenceEChange<EObject>) eChange).getAffectedElement());
       }
     }
     if (!_matched) {
       if (eChange instanceof InsertRootEObject) {
-        _matched=true;
-        _switchResult = Set.<EObject>of(((InsertRootEObject<EObject>)eChange).getNewValue());
+        _matched = true;
+        _switchResult = Set.<EObject>of(((InsertRootEObject<EObject>) eChange).getNewValue());
       }
     }
     if (!_matched) {
       if (eChange instanceof RemoveRootEObject) {
-        _matched=true;
-        _switchResult = Set.<EObject>of(((RemoveRootEObject<EObject>)eChange).getOldValue());
+        _matched = true;
+        _switchResult = Set.<EObject>of(((RemoveRootEObject<EObject>) eChange).getOldValue());
       }
     }
     return _switchResult;
@@ -161,43 +161,48 @@ public class TransactionalChangeImpl<Element extends Object> implements Transact
     Set<EObject> _switchResult = null;
     boolean _matched = false;
     if (eChange instanceof UpdateAttributeEChange) {
-      _matched=true;
-      _switchResult = Set.<EObject>of(((UpdateAttributeEChange<EObject>)eChange).getAffectedElement());
+      _matched = true;
+      _switchResult = Set.<EObject>of(((UpdateAttributeEChange<EObject>) eChange).getAffectedElement());
     }
     if (!_matched) {
       if (eChange instanceof ReplaceSingleValuedEReference) {
-        _matched=true;
-        _switchResult = TransactionalChangeImpl.<EObject>setOfNotNull(((ReplaceSingleValuedEReference<EObject>)eChange).getAffectedElement(), ((ReplaceSingleValuedEReference<EObject>)eChange).getOldValue(), ((ReplaceSingleValuedEReference<EObject>)eChange).getNewValue());
+        _matched = true;
+        _switchResult = TransactionalChangeImpl.<EObject>setOfNotNull(
+            ((ReplaceSingleValuedEReference<EObject>) eChange).getAffectedElement(),
+            ((ReplaceSingleValuedEReference<EObject>) eChange).getOldValue(),
+            ((ReplaceSingleValuedEReference<EObject>) eChange).getNewValue());
       }
     }
     if (!_matched) {
       if (eChange instanceof InsertEReference) {
-        _matched=true;
-        _switchResult = Set.<EObject>of(((InsertEReference<EObject>)eChange).getAffectedElement(), ((InsertEReference<EObject>)eChange).getNewValue());
+        _matched = true;
+        _switchResult = Set.<EObject>of(((InsertEReference<EObject>) eChange).getAffectedElement(),
+            ((InsertEReference<EObject>) eChange).getNewValue());
       }
     }
     if (!_matched) {
       if (eChange instanceof RemoveEReference) {
-        _matched=true;
-        _switchResult = Set.<EObject>of(((RemoveEReference<EObject>)eChange).getAffectedElement(), ((RemoveEReference<EObject>)eChange).getOldValue());
+        _matched = true;
+        _switchResult = Set.<EObject>of(((RemoveEReference<EObject>) eChange).getAffectedElement(),
+            ((RemoveEReference<EObject>) eChange).getOldValue());
       }
     }
     if (!_matched) {
       if (eChange instanceof EObjectExistenceEChange) {
-        _matched=true;
-        _switchResult = Set.<EObject>of(((EObjectExistenceEChange<EObject>)eChange).getAffectedElement());
+        _matched = true;
+        _switchResult = Set.<EObject>of(((EObjectExistenceEChange<EObject>) eChange).getAffectedElement());
       }
     }
     if (!_matched) {
       if (eChange instanceof InsertRootEObject) {
-        _matched=true;
-        _switchResult = Set.<EObject>of(((InsertRootEObject<EObject>)eChange).getNewValue());
+        _matched = true;
+        _switchResult = Set.<EObject>of(((InsertRootEObject<EObject>) eChange).getNewValue());
       }
     }
     if (!_matched) {
       if (eChange instanceof RemoveRootEObject) {
-        _matched=true;
-        _switchResult = Set.<EObject>of(((RemoveRootEObject<EObject>)eChange).getOldValue());
+        _matched = true;
+        _switchResult = Set.<EObject>of(((RemoveRootEObject<EObject>) eChange).getOldValue());
       }
     }
     return _switchResult;
@@ -237,7 +242,7 @@ public class TransactionalChangeImpl<Element extends Object> implements Transact
       } else {
         boolean _xifexpression_2 = false;
         if ((obj instanceof TransactionalChange)) {
-          List _eChanges = ((TransactionalChange)obj).getEChanges();
+          List _eChanges = ((TransactionalChange) obj).getEChanges();
           _xifexpression_2 = Objects.equals(this.eChanges, _eChanges);
         } else {
           _xifexpression_2 = false;
@@ -353,67 +358,81 @@ public class TransactionalChangeImpl<Element extends Object> implements Transact
   private CharSequence getStringRepresentation(final EChange<?> change) {
     boolean _matched = false;
     if (change instanceof InsertRootEObject) {
-      _matched=true;
-      return "insert " + ((InsertRootEObject<?>)change).getNewValue() + " at " + ((InsertRootEObject<?>)change).getUri() + " (index " + ((InsertRootEObject<?>)change).getIndex() + ")";
+      _matched = true;
+      return "insert " + ((InsertRootEObject<?>) change).getNewValue() + " at "
+          + ((InsertRootEObject<?>) change).getUri() + " (index " + ((InsertRootEObject<?>) change).getIndex() + ")";
     }
     if (!_matched) {
       if (change instanceof RemoveRootEObject) {
-        _matched=true;
-        return "remove " + ((RemoveRootEObject<?>)change).getOldValue() + " from " + ((RemoveRootEObject<?>)change).getUri() + " (index " + ((RemoveRootEObject<?>)change).getIndex() + ")";
+        _matched = true;
+        return "remove " + ((RemoveRootEObject<?>) change).getOldValue() + " from "
+            + ((RemoveRootEObject<?>) change).getUri() + " (index " + ((RemoveRootEObject<?>) change).getIndex() + ")";
       }
     }
     if (!_matched) {
       if (change instanceof CreateEObject) {
-        _matched=true;
-        return "create " + ((CreateEObject<?>)change).getAffectedElement();
+        _matched = true;
+        return "create " + ((CreateEObject<?>) change).getAffectedElement();
       }
     }
     if (!_matched) {
       if (change instanceof DeleteEObject) {
-        _matched=true;
-        return "delete " + ((DeleteEObject<?>)change).getAffectedElement();
+        _matched = true;
+        return "delete " + ((DeleteEObject<?>) change).getAffectedElement();
       }
     }
     if (!_matched) {
       if (change instanceof UnsetFeature) {
-        _matched=true;
-        return this.getAffectedFeatureString(((FeatureEChange<?, ?>)change)) + " = ∅";
+        _matched = true;
+        return this.getAffectedFeatureString(((FeatureEChange<?, ?>) change)) + " = ∅";
       }
     }
     if (!_matched) {
       if (change instanceof ReplaceSingleValuedEAttribute) {
-        _matched=true;
-        return this.getAffectedFeatureString(((FeatureEChange<?, ?>)change)) + " = " + ((ReplaceSingleValuedEAttribute<?, ?>)change).getNewValue() + " (was " + ((ReplaceSingleValuedEAttribute<?, ?>)change).getOldValue() + ")";
+        _matched = true;
+        return this.getAffectedFeatureString(((FeatureEChange<?, ?>) change)) + " = "
+            + ((ReplaceSingleValuedEAttribute<?, ?>) change).getNewValue() + " (was "
+            + ((ReplaceSingleValuedEAttribute<?, ?>) change).getOldValue() + ")";
       }
     }
     if (!_matched) {
       if (change instanceof ReplaceSingleValuedEReference) {
-        _matched=true;
-        return this.getAffectedFeatureString(((FeatureEChange<?, ?>)change)) + " = " + ((ReplaceSingleValuedEReference<?>)change).getNewValue() + " (was " + ((ReplaceSingleValuedEReference<?>)change).getOldValue() + ")";
+        _matched = true;
+        return this.getAffectedFeatureString(((FeatureEChange<?, ?>) change)) + " = "
+            + ((ReplaceSingleValuedEReference<?>) change).getNewValue() + " (was "
+            + ((ReplaceSingleValuedEReference<?>) change).getOldValue() + ")";
       }
     }
     if (!_matched) {
       if (change instanceof InsertEAttributeValue) {
-        _matched=true;
-        return this.getAffectedFeatureString(((FeatureEChange<?, ?>)change)) + " += " + ((InsertEAttributeValue<?, ?>)change).getNewValue() + " (index " + ((InsertEAttributeValue<?, ?>)change).getIndex() + ")";
+        _matched = true;
+        return this.getAffectedFeatureString(((FeatureEChange<?, ?>) change)) + " += "
+            + ((InsertEAttributeValue<?, ?>) change).getNewValue() + " (index "
+            + ((InsertEAttributeValue<?, ?>) change).getIndex() + ")";
       }
     }
     if (!_matched) {
       if (change instanceof InsertEReference) {
-        _matched=true;
-        return this.getAffectedFeatureString(((FeatureEChange<?, ?>)change)) + " += " + ((InsertEReference<?>)change).getNewValue() + " (index " + ((InsertEReference<?>)change).getIndex() + ")";
+        _matched = true;
+        return this.getAffectedFeatureString(((FeatureEChange<?, ?>) change)) + " += "
+            + ((InsertEReference<?>) change).getNewValue() + " (index " + ((InsertEReference<?>) change).getIndex()
+            + ")";
       }
     }
     if (!_matched) {
       if (change instanceof RemoveEAttributeValue) {
-        _matched=true;
-        return this.getAffectedFeatureString(((FeatureEChange<?, ?>)change)) + " -= " + ((RemoveEAttributeValue<?, ?>)change).getOldValue() + " (index " + ((RemoveEAttributeValue<?, ?>)change).getIndex() + ")";
+        _matched = true;
+        return this.getAffectedFeatureString(((FeatureEChange<?, ?>) change)) + " -= "
+            + ((RemoveEAttributeValue<?, ?>) change).getOldValue() + " (index "
+            + ((RemoveEAttributeValue<?, ?>) change).getIndex() + ")";
       }
     }
     if (!_matched) {
       if (change instanceof RemoveEReference) {
-        _matched=true;
-        return this.getAffectedFeatureString(((FeatureEChange<?, ?>)change)) + " -= " + ((RemoveEReference<?>)change).getOldValue() + " (index " + ((RemoveEReference<?>)change).getIndex() + ")";
+        _matched = true;
+        return this.getAffectedFeatureString(((FeatureEChange<?, ?>) change)) + " -= "
+            + ((RemoveEReference<?>) change).getOldValue() + " (index " + ((RemoveEReference<?>) change).getIndex()
+            + ")";
       }
     }
     return null;

--- a/composite/src/main/java/tools/vitruv/change/composite/description/impl/TransactionalChangeImpl.java
+++ b/composite/src/main/java/tools/vitruv/change/composite/description/impl/TransactionalChangeImpl.java
@@ -35,7 +35,8 @@ import tools.vitruv.change.composite.MetamodelDescriptor;
 import tools.vitruv.change.composite.description.TransactionalChange;
 import tools.vitruv.change.interaction.UserInteractionBase;
 
-public class TransactionalChangeImpl<Element extends Object> implements TransactionalChange<Element> {
+public class TransactionalChangeImpl<Element extends Object>
+    implements TransactionalChange<Element> {
   private List<? extends EChange<Element>> eChanges;
 
   private final List<UserInteractionBase> userInteractions = new ArrayList<UserInteractionBase>();
@@ -63,20 +64,21 @@ public class TransactionalChangeImpl<Element extends Object> implements Transact
     boolean _matched = false;
     if (eChange instanceof FeatureEChange) {
       _matched = true;
-      EObject _affectedElement = ((FeatureEChange<EObject, ?>) eChange).getAffectedElement();
+      EObject affectedElement = ((FeatureEChange<EObject, ?>) eChange).getAffectedElement();
       URI _objectUri = null;
-      if (_affectedElement != null) {
-        _objectUri = TransactionalChangeImpl.getObjectUri(_affectedElement);
+      if (affectedElement != null) {
+        _objectUri = TransactionalChangeImpl.getObjectUri(affectedElement);
       }
       _switchResult = _objectUri;
     }
     if (!_matched) {
       if (eChange instanceof EObjectExistenceEChange) {
         _matched = true;
-        EObject _affectedElement = ((EObjectExistenceEChange<EObject>) eChange).getAffectedElement();
+        EObject affectedElement =
+            ((EObjectExistenceEChange<EObject>) eChange).getAffectedElement();
         URI _objectUri = null;
-        if (_affectedElement != null) {
-          _objectUri = TransactionalChangeImpl.getObjectUri(_affectedElement);
+        if (affectedElement != null) {
+          _objectUri = TransactionalChangeImpl.getObjectUri(affectedElement);
         }
         _switchResult = _objectUri;
       }
@@ -110,7 +112,8 @@ public class TransactionalChangeImpl<Element extends Object> implements Transact
         changedPackages.add(currentPackage);
       }
     }
-    Preconditions.checkState(!changedPackages.isEmpty(), "Cannot identify the packages of this change:%s%s",
+    Preconditions.checkState(!changedPackages.isEmpty(),
+        "Cannot identify the packages of this change:%s%s",
         System.lineSeparator(), this);
     return MetamodelDescriptor.of(changedPackages);
   }
@@ -139,7 +142,8 @@ public class TransactionalChangeImpl<Element extends Object> implements Transact
     if (!_matched) {
       if (eChange instanceof EObjectExistenceEChange) {
         _matched = true;
-        _switchResult = Set.<EObject>of(((EObjectExistenceEChange<EObject>) eChange).getAffectedElement());
+        _switchResult = Set.<EObject>of(
+            ((EObjectExistenceEChange<EObject>) eChange).getAffectedElement());
       }
     }
     if (!_matched) {
@@ -162,7 +166,8 @@ public class TransactionalChangeImpl<Element extends Object> implements Transact
     boolean _matched = false;
     if (eChange instanceof UpdateAttributeEChange) {
       _matched = true;
-      _switchResult = Set.<EObject>of(((UpdateAttributeEChange<EObject>) eChange).getAffectedElement());
+      _switchResult = Set.<EObject>of(
+          ((UpdateAttributeEChange<EObject>) eChange).getAffectedElement());
     }
     if (!_matched) {
       if (eChange instanceof ReplaceSingleValuedEReference) {
@@ -190,7 +195,8 @@ public class TransactionalChangeImpl<Element extends Object> implements Transact
     if (!_matched) {
       if (eChange instanceof EObjectExistenceEChange) {
         _matched = true;
-        _switchResult = Set.<EObject>of(((EObjectExistenceEChange<EObject>) eChange).getAffectedElement());
+        _switchResult = Set.<EObject>of(
+            ((EObjectExistenceEChange<EObject>) eChange).getAffectedElement());
       }
     }
     if (!_matched) {
@@ -215,7 +221,8 @@ public class TransactionalChangeImpl<Element extends Object> implements Transact
 
   @Override
   public void setUserInteractions(final Iterable<UserInteractionBase> userInteractions) {
-    Preconditions.<Iterable<UserInteractionBase>>checkNotNull(userInteractions, "Interactions must not be null");
+    Preconditions.<Iterable<UserInteractionBase>>checkNotNull(userInteractions,
+        "Interactions must not be null");
     this.userInteractions.clear();
     Iterables.<UserInteractionBase>addAll(this.userInteractions, userInteractions);
   }
@@ -242,8 +249,8 @@ public class TransactionalChangeImpl<Element extends Object> implements Transact
       } else {
         boolean _xifexpression_2 = false;
         if ((obj instanceof TransactionalChange)) {
-          List _eChanges = ((TransactionalChange) obj).getEChanges();
-          _xifexpression_2 = Objects.equals(this.eChanges, _eChanges);
+          List objEChanges = ((TransactionalChange) obj).getEChanges();
+          _xifexpression_2 = Objects.equals(this.eChanges, objEChanges);
         } else {
           _xifexpression_2 = false;
         }
@@ -318,7 +325,8 @@ public class TransactionalChangeImpl<Element extends Object> implements Transact
     return _xifexpression;
   }
 
-  private static <T extends Object> Set<T> setOfNotNull(final T element1, final T element2, final T element3) {
+  private static <T extends Object> Set<T> setOfNotNull(final T element1, final T element2,
+      final T element3) {
     Set<T> _xifexpression = null;
     if ((element1 == null)) {
       _xifexpression = TransactionalChangeImpl.<T>setOfNotNull(element2, element3);
@@ -348,7 +356,8 @@ public class TransactionalChangeImpl<Element extends Object> implements Transact
       StringBuilder _builder = new StringBuilder();
       _builder.append(this.getClass().getSimpleName()).append(": [").append(System.lineSeparator());
       for (EChange<Element> eChange : this.eChanges) {
-        _builder.append("\t").append(this.getStringRepresentation(eChange)).append(System.lineSeparator());
+        _builder.append("\t").append(this.getStringRepresentation(eChange))
+            .append(System.lineSeparator());
       }
       _builder.append("]").append(System.lineSeparator());
       return _builder.toString();
@@ -360,13 +369,15 @@ public class TransactionalChangeImpl<Element extends Object> implements Transact
     if (change instanceof InsertRootEObject) {
       _matched = true;
       return "insert " + ((InsertRootEObject<?>) change).getNewValue() + " at "
-          + ((InsertRootEObject<?>) change).getUri() + " (index " + ((InsertRootEObject<?>) change).getIndex() + ")";
+          + ((InsertRootEObject<?>) change).getUri() + " (index "
+          + ((InsertRootEObject<?>) change).getIndex() + ")";
     }
     if (!_matched) {
       if (change instanceof RemoveRootEObject) {
         _matched = true;
         return "remove " + ((RemoveRootEObject<?>) change).getOldValue() + " from "
-            + ((RemoveRootEObject<?>) change).getUri() + " (index " + ((RemoveRootEObject<?>) change).getIndex() + ")";
+            + ((RemoveRootEObject<?>) change).getUri() + " (index "
+            + ((RemoveRootEObject<?>) change).getIndex() + ")";
       }
     }
     if (!_matched) {
@@ -415,7 +426,8 @@ public class TransactionalChangeImpl<Element extends Object> implements Transact
       if (change instanceof InsertEReference) {
         _matched = true;
         return this.getAffectedFeatureString(((FeatureEChange<?, ?>) change)) + " += "
-            + ((InsertEReference<?>) change).getNewValue() + " (index " + ((InsertEReference<?>) change).getIndex()
+            + ((InsertEReference<?>) change).getNewValue() + " (index "
+            + ((InsertEReference<?>) change).getIndex()
             + ")";
       }
     }
@@ -431,7 +443,8 @@ public class TransactionalChangeImpl<Element extends Object> implements Transact
       if (change instanceof RemoveEReference) {
         _matched = true;
         return this.getAffectedFeatureString(((FeatureEChange<?, ?>) change)) + " -= "
-            + ((RemoveEReference<?>) change).getOldValue() + " (index " + ((RemoveEReference<?>) change).getIndex()
+            + ((RemoveEReference<?>) change).getOldValue() + " (index "
+            + ((RemoveEReference<?>) change).getIndex()
             + ")";
       }
     }

--- a/composite/src/main/java/tools/vitruv/change/composite/description/impl/TransactionalChangeImpl.java
+++ b/composite/src/main/java/tools/vitruv/change/composite/description/impl/TransactionalChangeImpl.java
@@ -35,6 +35,11 @@ import tools.vitruv.change.composite.MetamodelDescriptor;
 import tools.vitruv.change.composite.description.TransactionalChange;
 import tools.vitruv.change.interaction.UserInteractionBase;
 
+/**
+ * Implementation of a {@link TransactionalChange}.
+ *
+ * @param <Element> the type of elements affected by this change
+ */
 public class TransactionalChangeImpl<Element extends Object>
     implements TransactionalChange<Element> {
   private List<? extends EChange<Element>> eChanges;

--- a/composite/src/main/java/tools/vitruv/change/composite/recording/ChangeRecorder.java
+++ b/composite/src/main/java/tools/vitruv/change/composite/recording/ChangeRecorder.java
@@ -60,7 +60,8 @@ public class ChangeRecorder implements AutoCloseable {
     @Override
     public void notifyChanged(final Notification notification) {
       this.handleAdaptersForResourceAndResourceSetChanges(notification);
-      final Iterable<? extends EChange<EObject>> newChanges = this.extractRelevantChanges(notification);
+      final Iterable<? extends EChange<EObject>> newChanges =
+          this.extractRelevantChanges(notification);
       if (this.outer.isRecording) {
         Iterables.<EChange<EObject>>addAll(this.outer.resultChanges, newChanges);
       }
@@ -68,7 +69,8 @@ public class ChangeRecorder implements AutoCloseable {
 
     private void handleAdaptersForResourceAndResourceSetChanges(final Notification notification) {
       if (((notification.getNotifier() instanceof ResourceSet)
-          && (notification.getFeatureID(ResourceSet.class) == ResourceSet.RESOURCE_SET__RESOURCES))) {
+          && (notification.getFeatureID(ResourceSet.class)
+              == ResourceSet.RESOURCE_SET__RESOURCES))) {
         int _eventType = notification.getEventType();
         switch (_eventType) {
           case Notification.ADD:
@@ -101,7 +103,8 @@ public class ChangeRecorder implements AutoCloseable {
       }
       if (!_matched) {
         if (((notification.getNotifier() instanceof ResourceSet)
-            && (notification.getFeatureID(ResourceSet.class) == ResourceSet.RESOURCE_SET__RESOURCES))) {
+            && (notification.getFeatureID(ResourceSet.class)
+                == ResourceSet.RESOURCE_SET__RESOURCES))) {
           _matched = true;
         }
       }
@@ -278,7 +281,8 @@ public class ChangeRecorder implements AutoCloseable {
     }
   }
 
-  private final ChangeRecorder.NotificationRecorder recordingAdapter = new ChangeRecorder.NotificationRecorder(this);
+  private final ChangeRecorder.NotificationRecorder recordingAdapter =
+      new ChangeRecorder.NotificationRecorder(this);
 
   private final Set<Notifier> rootObjects = new HashSet<Notifier>();
 
@@ -296,10 +300,12 @@ public class ChangeRecorder implements AutoCloseable {
 
   public ChangeRecorder(final ResourceSet resourceSet) {
     this.resourceSet = resourceSet;
-    final BiFunction<EObject, EObject, Boolean> _function = (EObject affectedObject, EObject addedObject) -> {
+    final BiFunction<EObject, EObject, Boolean> _function =
+        (EObject affectedObject, EObject addedObject) -> {
       return Boolean.valueOf(this.isCreateChange(affectedObject, addedObject));
     };
-    NotificationToEChangeConverter _notificationToEChangeConverter = new NotificationToEChangeConverter(_function);
+    NotificationToEChangeConverter _notificationToEChangeConverter =
+        new NotificationToEChangeConverter(_function);
     this.converter = _notificationToEChangeConverter;
   }
 
@@ -415,7 +421,8 @@ public class ChangeRecorder implements AutoCloseable {
     this.checkNotDisposed();
     Preconditions.checkState(this.isRecording, "This recorder is not recording");
     this.isRecording = false;
-    this.resultChanges = List.<EChange<EObject>>copyOf(this.postprocessRemovals(this.resultChanges));
+    this.resultChanges =
+        List.<EChange<EObject>>copyOf(this.postprocessRemovals(this.resultChanges));
     return this.getChange();
   }
 
@@ -515,7 +522,8 @@ public class ChangeRecorder implements AutoCloseable {
     }
   }
 
-  private static void recursivelyInternal(final EObject object, final Function<Notifier, Boolean> action) {
+  private static void recursivelyInternal(final EObject object,
+      final Function<Notifier, Boolean> action) {
     Boolean _apply = action.apply(object);
     if ((_apply).booleanValue()) {
       for (final TreeIterator<Notifier> properContents = EcoreUtil.<Notifier>getAllProperContents(

--- a/composite/src/main/java/tools/vitruv/change/composite/recording/ChangeRecorder.java
+++ b/composite/src/main/java/tools/vitruv/change/composite/recording/ChangeRecorder.java
@@ -407,61 +407,51 @@ public class ChangeRecorder implements AutoCloseable {
    * of the list. Contained elements are deleted before their container.
    */
   private List<EChange<EObject>> postprocessRemovals(final List<EChange<EObject>> changes) {
-    boolean _isEmpty = changes.isEmpty();
-    if (_isEmpty) {
+    if (changes.isEmpty()) {
       return changes;
     }
-    final Set<EObject> removedElements = new HashSet<EObject>();
-    for (final EChange<EObject> eChange : changes) {
-      {
-        boolean _matched = false;
-        if (eChange instanceof EObjectSubtractedEChange) {
-          _matched=true;
-          boolean _isContainmentRemoval = EChangeUtil.isContainmentRemoval(eChange);
-          if (_isContainmentRemoval) {
-            EObject _oldValue = ((EObjectSubtractedEChange<EObject>)eChange).getOldValue();
-            removedElements.add(_oldValue);
-          }
-        }
-        boolean _matched_1 = false;
-        if (eChange instanceof EObjectAddedEChange) {
-          _matched_1=true;
-          boolean _isContainmentInsertion = EChangeUtil.isContainmentInsertion(eChange);
-          if (_isContainmentInsertion) {
-            EObject _newValue = ((EObjectAddedEChange<EObject>)eChange).getNewValue();
-            removedElements.remove(_newValue);
-          }
-        }
-      }
-    }
-    boolean _isEmpty_1 = removedElements.isEmpty();
-    boolean _not = (!_isEmpty_1);
-    if (_not) {
-      final Map<EObject, Iterable<EObject>> allElementsToDelete = new HashMap<EObject, Iterable<EObject>>();
-      for (EObject element : removedElements) {
-        boolean _exists = allElementsToDelete.values().stream().anyMatch(it -> Iterables.contains(it, element));
-        if (_exists) {
-          continue;
-        }
-        List<EObject> elementsToDelete = new ArrayList<>(Lists.newArrayList(element.eAllContents()));
-        java.util.Collections.reverse(elementsToDelete);
-        for (EObject child : elementsToDelete) {
-          if (allElementsToDelete.containsKey(child)) {
-            allElementsToDelete.remove(child);
-          }
-        }
-        elementsToDelete.add(element);
-        allElementsToDelete.put(element, elementsToDelete);
-      }
-      List<EChange<EObject>> _list = new ArrayList<>();
-      for (Iterable<EObject> elementsToDelete : allElementsToDelete.values()) {
-        for (EObject it : elementsToDelete) {
-          _list.add(this.converter.createDeleteChange(it));
-        }
-      }
-      Iterables.<EChange<EObject>>addAll(changes, _list);
-    }
+    Set<EObject> removedElements = findRemovedElements(changes);
+    appendDeleteChanges(removedElements, changes);
     return changes;
+  }
+
+  private Set<EObject> findRemovedElements(final List<EChange<EObject>> changes) {
+    final Set<EObject> removedElements = new HashSet<>();
+    for (final EChange<EObject> eChange : changes) {
+      if (eChange instanceof EObjectSubtractedEChange && EChangeUtil.isContainmentRemoval(eChange)) {
+        removedElements.add(((EObjectSubtractedEChange<EObject>) eChange).getOldValue());
+      }
+      if (eChange instanceof EObjectAddedEChange && EChangeUtil.isContainmentInsertion(eChange)) {
+        removedElements.remove(((EObjectAddedEChange<EObject>) eChange).getNewValue());
+      }
+    }
+    return removedElements;
+  }
+
+  private void appendDeleteChanges(final Set<EObject> removedElements, final List<EChange<EObject>> changes) {
+    if (removedElements.isEmpty()) {
+      return;
+    }
+    final Map<EObject, Iterable<EObject>> allElementsToDelete = new HashMap<>();
+    for (EObject element : removedElements) {
+      boolean exists = allElementsToDelete.values().stream().anyMatch(it -> Iterables.contains(it, element));
+      if (exists) {
+        continue;
+      }
+      List<EObject> elementsToDelete = new ArrayList<>(Lists.newArrayList(element.eAllContents()));
+      java.util.Collections.reverse(elementsToDelete);
+      for (EObject child : elementsToDelete) {
+        allElementsToDelete.remove(child);
+      }
+      elementsToDelete.add(element);
+      allElementsToDelete.put(element, elementsToDelete);
+    }
+    
+    for (Iterable<EObject> elementsToDelete : allElementsToDelete.values()) {
+      for (EObject it : elementsToDelete) {
+        changes.add(this.converter.createDeleteChange(it));
+      }
+    }
   }
 
   public TransactionalChange<EObject> getChange() {

--- a/composite/src/main/java/tools/vitruv/change/composite/recording/ChangeRecorder.java
+++ b/composite/src/main/java/tools/vitruv/change/composite/recording/ChangeRecorder.java
@@ -35,13 +35,20 @@ import tools.vitruv.change.composite.description.VitruviusChangeFactory;
 
 /**
  * Records changes to model elements as a {@link TransactionalChange}.
- * Recording can be started with {@link #beginRecording} and ended with {@link #endRecording}. The recorder assumes
- * that all objects that have been removed from their containment reference without being added to a new containment
- * reference while changes were being recorded have been deleted, resulting in an appropriate delete change.
- * The recorder considers resources being loaded as existing and does thus not produce changes for it.
+ * Recording can be started with {@link #beginRecording} and ended with
+ * {@link #endRecording}.
+ * The recorder assumes that all objects that have been removed from their
+ * containment reference
+ * without being added to a new containment reference while changes were being
+ * recorded have
+ * been deleted, resulting in an appropriate delete change.
+ * The recorder considers resources being loaded as existing and does thus not
+ * produce changes
+ * for it.
  * 
  * Does not record changes of the <code>xmi:id</code> tag in an
- * {@code org.eclipse.emf.ecore.xmi.XMLResource} if it is not stored in the element
+ * {@code org.eclipse.emf.ecore.xmi.XMLResource} if it is not stored in the
+ * element
  * but directly in the <code>Resource</code>.
  */
 public class ChangeRecorder implements AutoCloseable {
@@ -60,8 +67,8 @@ public class ChangeRecorder implements AutoCloseable {
     }
 
     private void handleAdaptersForResourceAndResourceSetChanges(final Notification notification) {
-      if (((notification.getNotifier() instanceof ResourceSet) && 
-        (notification.getFeatureID(ResourceSet.class) == ResourceSet.RESOURCE_SET__RESOURCES))) {
+      if (((notification.getNotifier() instanceof ResourceSet) &&
+          (notification.getFeatureID(ResourceSet.class) == ResourceSet.RESOURCE_SET__RESOURCES))) {
         int _eventType = notification.getEventType();
         switch (_eventType) {
           case Notification.ADD:
@@ -81,21 +88,21 @@ public class ChangeRecorder implements AutoCloseable {
       final Object feature = _feature;
       boolean _matched = false;
       if (feature instanceof EReference) {
-        boolean _isContainment = ((EReference)feature).isContainment();
+        boolean _isContainment = ((EReference) feature).isContainment();
         if (_isContainment) {
-          _matched=true;
+          _matched = true;
         }
       }
       if (!_matched) {
-        if (((notification.getNotifier() instanceof Resource) && 
-          (notification.getFeatureID(Resource.class) == Resource.RESOURCE__CONTENTS))) {
-          _matched=true;
+        if (((notification.getNotifier() instanceof Resource) &&
+            (notification.getFeatureID(Resource.class) == Resource.RESOURCE__CONTENTS))) {
+          _matched = true;
         }
       }
       if (!_matched) {
-        if (((notification.getNotifier() instanceof ResourceSet) && 
-          (notification.getFeatureID(ResourceSet.class) == ResourceSet.RESOURCE_SET__RESOURCES))) {
-          _matched=true;
+        if (((notification.getNotifier() instanceof ResourceSet) &&
+            (notification.getFeatureID(ResourceSet.class) == ResourceSet.RESOURCE_SET__RESOURCES))) {
+          _matched = true;
         }
       }
       if (_matched) {
@@ -129,18 +136,20 @@ public class ChangeRecorder implements AutoCloseable {
         }
       }
       if (!_matched) {
-        if (((notification.getNotifier() instanceof Resource) && 
-          (notification.getFeatureID(Resource.class) == Resource.RESOURCE__IS_LOADED))) {
-          _matched=true;
+        if (((notification.getNotifier() instanceof Resource) &&
+            (notification.getFeatureID(Resource.class) == Resource.RESOURCE__IS_LOADED))) {
+          _matched = true;
           Object _notifier = notification.getNotifier();
           this.finishLoadingResource(((Resource) _notifier));
         }
       }
     }
 
-    private Iterable<? extends EChange<EObject>> extractRelevantChanges(final Notification notification) {
+    private Iterable<? extends EChange<EObject>> extractRelevantChanges(
+        final Notification notification) {
       Iterable<? extends EChange<EObject>> _xifexpression = null;
-      if ((this.affectsLoadingResource(notification) || this.affectsUnloadingResource(notification))) {
+      if ((this.affectsLoadingResource(notification)
+          || this.affectsUnloadingResource(notification))) {
         _xifexpression = List.of();
       } else {
         NotificationInfo _notificationInfo = new NotificationInfo(notification);
@@ -153,13 +162,13 @@ public class ChangeRecorder implements AutoCloseable {
         final Consumer<EChange<EObject>> _function = (EChange<EObject> it) -> {
           boolean _matched = false;
           if (it instanceof EObjectAddedEChange) {
-            _matched=true;
-            EObject _newValue = ((EObjectAddedEChange<EObject>)it).getNewValue();
+            _matched = true;
+            EObject _newValue = ((EObjectAddedEChange<EObject>) it).getNewValue();
             this.outer.existingObjects.add(_newValue);
             boolean _matched_1 = false;
             if (it instanceof UpdateReferenceEChange) {
-              _matched_1=true;
-              EObject _affectedElement = ((UpdateReferenceEChange<EObject>)it).getAffectedElement();
+              _matched_1 = true;
+              EObject _affectedElement = ((UpdateReferenceEChange<EObject>) it).getAffectedElement();
               this.outer.existingObjects.add(_affectedElement);
             }
           }
@@ -179,7 +188,7 @@ public class ChangeRecorder implements AutoCloseable {
         boolean _xblockexpression = false;
         {
           if ((it instanceof EObject)) {
-            this.outer.existingObjects.add(((EObject)it));
+            this.outer.existingObjects.add(((EObject) it));
           }
           _xblockexpression = this.outer.addAdapter(it);
         }
@@ -200,8 +209,8 @@ public class ChangeRecorder implements AutoCloseable {
       final EObject newEObject = _xifexpression;
       boolean _and = false;
       Resource _eResource = null;
-      if (newEObject!=null) {
-        _eResource=newEObject.eResource();
+      if (newEObject != null) {
+        _eResource = newEObject.eResource();
       }
       boolean _tripleNotEquals = (_eResource != null);
       if (!_tripleNotEquals) {
@@ -219,15 +228,15 @@ public class ChangeRecorder implements AutoCloseable {
         Object _notifier_1 = notification.getNotifier();
         final Resource resource = ((Resource) _notifier_1);
         final ResourceSet resourceSet = resource.getResourceSet();
-        return (((!resource.isLoaded()) && (resourceSet != null)) && 
-          resourceSet.getURIConverter().exists(resource.getURI(), Map.of()));
+        return (((!resource.isLoaded()) && (resourceSet != null)) &&
+            resourceSet.getURIConverter().exists(resource.getURI(), Map.of()));
       } else {
         return false;
       }
     }
 
     private void infect(final Object newValue) {
-      if (((Notifier) newValue)!=null) {
+      if (((Notifier) newValue) != null) {
         final Function<Notifier, Boolean> _function = (Notifier it) -> {
           boolean _xblockexpression = false;
           {
@@ -243,7 +252,7 @@ public class ChangeRecorder implements AutoCloseable {
     private boolean desinfect(final Object oldValue) {
       boolean _xifexpression = false;
       if ((oldValue instanceof Notifier)) {
-        _xifexpression = this.outer.toDesinfect.add(((Notifier)oldValue));
+        _xifexpression = this.outer.toDesinfect.add(((Notifier) oldValue));
       }
       return _xifexpression;
     }
@@ -295,8 +304,8 @@ public class ChangeRecorder implements AutoCloseable {
 
   private boolean isCreateChange(final EObject affectedObject, final EObject addedObject) {
     boolean create = ((addedObject != null) && (!this.existingObjects.contains(addedObject)));
-    create = (create && (((addedObject.eResource() == null) || (affectedObject == null)) || 
-      Objects.equals(addedObject.eResource(), affectedObject.eResource())));
+    create = (create && (((addedObject.eResource() == null) || (affectedObject == null)) ||
+        Objects.equals(addedObject.eResource(), affectedObject.eResource())));
     if (create) {
       this.existingObjects.add(addedObject);
     }
@@ -304,7 +313,9 @@ public class ChangeRecorder implements AutoCloseable {
   }
 
   /**
-   * Add the given elements and all its contained elements ({@link Resource}s, {@link EObject}s) to the recorder.
+   * Add the given elements and all its contained elements ({@link Resource}s,
+   * {@link EObject}s)
+   * to the recorder.
    * 
    * @param notifier - the {@link Notifier} to add the recorder to
    * @throws IllegalStateException if the recorder is already disposed
@@ -312,15 +323,15 @@ public class ChangeRecorder implements AutoCloseable {
   public void addToRecording(final Notifier notifier) {
     this.checkNotDisposed();
     Preconditions.<Notifier>checkNotNull(notifier, "notifier");
-    Preconditions.checkArgument(this.isInOurResourceSet(notifier), 
-      "cannot record changes in a different resource set!");
+    Preconditions.checkArgument(this.isInOurResourceSet(notifier),
+        "cannot record changes in a different resource set!");
     boolean _add = this.rootObjects.add(notifier);
     if (_add) {
       final Function<Notifier, Boolean> _function = (Notifier it) -> {
         boolean _xblockexpression = false;
         {
           if ((it instanceof EObject)) {
-            this.existingObjects.add(((EObject)it));
+            this.existingObjects.add(((EObject) it));
           }
           _xblockexpression = this.addAdapter(it);
         }
@@ -331,7 +342,10 @@ public class ChangeRecorder implements AutoCloseable {
   }
 
   /**
-   * Removes the given elements and all its contained elements (resources, EObjects) from the recorder.
+   * Removes the given elements and all its contained elements (resources,
+   * EObjects)
+   * from the recorder.
+   * 
    * @param notifier - the {@link Notifier} to remove the recorder from
    */
   public void removeFromRecording(final Notifier notifier) {
@@ -384,13 +398,16 @@ public class ChangeRecorder implements AutoCloseable {
   }
 
   private void checkNotDisposed() {
-    Preconditions.checkState((this.resultChanges != null), "This recorder has already been disposed!");
+    Preconditions.checkState((this.resultChanges != null),
+        "This recorder has already been disposed!");
   }
 
   /**
    * Ends recording changes on the registered elements.
-   * All elements that were removed from their container and not inserted into another one
-   * are treated as deleted and a delete change is created for them, inserted right after
+   * All elements that were removed from their container and not inserted into
+   * another one
+   * are treated as deleted and a delete change is created for them, inserted
+   * right after
    * the change describing the removal from the container.
    */
   public TransactionalChange<EObject> endRecording() {
@@ -402,8 +419,10 @@ public class ChangeRecorder implements AutoCloseable {
   }
 
   /**
-   * Creates {@link DeleteEObject} changes for every element implicitly deleted in the change
-   * sequence and all of its contained elements. The delete changes are appended at the end
+   * Creates {@link DeleteEObject} changes for every element implicitly deleted in
+   * the change
+   * sequence and all of its contained elements. The delete changes are appended
+   * at the end
    * of the list. Contained elements are deleted before their container.
    */
   private List<EChange<EObject>> postprocessRemovals(final List<EChange<EObject>> changes) {
@@ -418,23 +437,27 @@ public class ChangeRecorder implements AutoCloseable {
   private Set<EObject> findRemovedElements(final List<EChange<EObject>> changes) {
     final Set<EObject> removedElements = new HashSet<>();
     for (final EChange<EObject> eChange : changes) {
-      if (eChange instanceof EObjectSubtractedEChange && EChangeUtil.isContainmentRemoval(eChange)) {
+      if (eChange instanceof EObjectSubtractedEChange
+          && EChangeUtil.isContainmentRemoval(eChange)) {
         removedElements.add(((EObjectSubtractedEChange<EObject>) eChange).getOldValue());
       }
-      if (eChange instanceof EObjectAddedEChange && EChangeUtil.isContainmentInsertion(eChange)) {
+      if (eChange instanceof EObjectAddedEChange
+          && EChangeUtil.isContainmentInsertion(eChange)) {
         removedElements.remove(((EObjectAddedEChange<EObject>) eChange).getNewValue());
       }
     }
     return removedElements;
   }
 
-  private void appendDeleteChanges(final Set<EObject> removedElements, final List<EChange<EObject>> changes) {
+  private void appendDeleteChanges(final Set<EObject> removedElements,
+      final List<EChange<EObject>> changes) {
     if (removedElements.isEmpty()) {
       return;
     }
     final Map<EObject, Iterable<EObject>> allElementsToDelete = new HashMap<>();
     for (EObject element : removedElements) {
-      boolean exists = allElementsToDelete.values().stream().anyMatch(it -> Iterables.contains(it, element));
+      boolean exists = allElementsToDelete.values().stream()
+          .anyMatch(it -> Iterables.contains(it, element));
       if (exists) {
         continue;
       }
@@ -446,7 +469,7 @@ public class ChangeRecorder implements AutoCloseable {
       elementsToDelete.add(element);
       allElementsToDelete.put(element, elementsToDelete);
     }
-    
+
     for (Iterable<EObject> elementsToDelete : allElementsToDelete.values()) {
       for (EObject it : elementsToDelete) {
         changes.add(this.converter.createDeleteChange(it));
@@ -459,7 +482,8 @@ public class ChangeRecorder implements AutoCloseable {
     {
       this.checkNotDisposed();
       Preconditions.checkState((!this.isRecording), "This recorder is still recording!");
-      _xblockexpression = VitruviusChangeFactory.getInstance().<EObject>createTransactionalChange(this.resultChanges);
+      _xblockexpression = VitruviusChangeFactory.getInstance()
+          .<EObject>createTransactionalChange(this.resultChanges);
     }
     return _xblockexpression;
   }
@@ -468,7 +492,8 @@ public class ChangeRecorder implements AutoCloseable {
     return this.isRecording;
   }
 
-  private static void _recursively(final ResourceSet resourceSet, final Function<Notifier, Boolean> action) {
+  private static void _recursively(final ResourceSet resourceSet,
+      final Function<Notifier, Boolean> action) {
     Boolean _apply = action.apply(resourceSet);
     if ((_apply).booleanValue()) {
       final Consumer<Resource> _function = (Resource it) -> {
@@ -478,7 +503,8 @@ public class ChangeRecorder implements AutoCloseable {
     }
   }
 
-  private static void _recursively(final Resource resource, final Function<Notifier, Boolean> action) {
+  private static void _recursively(final Resource resource,
+      final Function<Notifier, Boolean> action) {
     Boolean _apply = action.apply(resource);
     if ((_apply).booleanValue()) {
       final Consumer<EObject> _function = (EObject it) -> {
@@ -491,7 +517,8 @@ public class ChangeRecorder implements AutoCloseable {
   private static void _recursively(final EObject object, final Function<Notifier, Boolean> action) {
     Boolean _apply = action.apply(object);
     if ((_apply).booleanValue()) {
-      for (final TreeIterator<Notifier> properContents = EcoreUtil.<Notifier>getAllProperContents(object, true); properContents.hasNext();) {
+      for (final TreeIterator<Notifier> properContents = EcoreUtil.<Notifier>getAllProperContents(
+          object, true); properContents.hasNext();) {
         Boolean _apply_1 = action.apply(properContents.next());
         boolean _not = (!(_apply_1).booleanValue());
         if (_not) {
@@ -502,14 +529,16 @@ public class ChangeRecorder implements AutoCloseable {
   }
 
   private boolean removeAdapter(final Notifier notifier) {
-    return ((!this.rootObjects.contains(notifier)) && notifier.eAdapters().remove(this.recordingAdapter));
+    return ((!this.rootObjects.contains(notifier))
+        && notifier.eAdapters().remove(this.recordingAdapter));
   }
 
   private boolean addAdapter(final Notifier notifier) {
     boolean _xblockexpression = false;
     {
       final EList<Adapter> eAdapters = notifier.eAdapters();
-      _xblockexpression = ((!eAdapters.contains(this.recordingAdapter)) && eAdapters.add(this.recordingAdapter));
+      _xblockexpression = ((!eAdapters.contains(this.recordingAdapter))
+          && eAdapters.add(this.recordingAdapter));
     }
     return _xblockexpression;
   }
@@ -518,32 +547,32 @@ public class ChangeRecorder implements AutoCloseable {
     boolean _switchResult = false;
     boolean _matched = false;
     if (Objects.equals(notifier, null)) {
-      _matched=true;
+      _matched = true;
       _switchResult = true;
     }
     if (!_matched) {
       if (notifier instanceof EObject) {
-        _matched=true;
+        _matched = true;
         Resource _eResource = null;
-        if (((EObject)notifier)!=null) {
-          _eResource=((EObject)notifier).eResource();
+        if (((EObject) notifier) != null) {
+          _eResource = ((EObject) notifier).eResource();
         }
         _switchResult = this.isInOurResourceSet(_eResource);
       }
     }
     if (!_matched) {
       if (notifier instanceof Resource) {
-        _matched=true;
+        _matched = true;
         ResourceSet _resourceSet = null;
-        if (((Resource)notifier)!=null) {
-          _resourceSet=((Resource)notifier).getResourceSet();
+        if (((Resource) notifier) != null) {
+          _resourceSet = ((Resource) notifier).getResourceSet();
         }
         _switchResult = this.isInOurResourceSet(_resourceSet);
       }
     }
     if (!_matched) {
       if (notifier instanceof ResourceSet) {
-        _matched=true;
+        _matched = true;
         _switchResult = Objects.equals(notifier, this.resourceSet);
       }
     }
@@ -554,22 +583,23 @@ public class ChangeRecorder implements AutoCloseable {
     }
     return _switchResult;
   }
+
   private static void recursively(final Notifier object, final Function<Notifier, Boolean> action) {
     if (object instanceof EObject
-         && action != null) {
-      _recursively((EObject)object, action);
+        && action != null) {
+      _recursively((EObject) object, action);
       return;
     } else if (object instanceof Resource
-         && action != null) {
-      _recursively((Resource)object, action);
+        && action != null) {
+      _recursively((Resource) object, action);
       return;
     } else if (object instanceof ResourceSet
-         && action != null) {
-      _recursively((ResourceSet)object, action);
+        && action != null) {
+      _recursively((ResourceSet) object, action);
       return;
     } else {
       throw new IllegalArgumentException("Unhandled parameter types: " +
-        Arrays.<Object>asList(object, action).toString());
+          Arrays.<Object>asList(object, action).toString());
     }
   }
 }

--- a/composite/src/main/java/tools/vitruv/change/composite/recording/ChangeRecorder.java
+++ b/composite/src/main/java/tools/vitruv/change/composite/recording/ChangeRecorder.java
@@ -74,8 +74,8 @@ public class ChangeRecorder implements AutoCloseable {
         int _eventType = notification.getEventType();
         switch (_eventType) {
           case Notification.ADD:
-            Object _newValue = notification.getNewValue();
-            this.startLoadingResource(((Resource) _newValue));
+            Object newValue = notification.getNewValue();
+            this.startLoadingResource(((Resource) newValue));
             break;
           case Notification.ADD_MANY:
             Object _newValue_1 = notification.getNewValue();
@@ -166,8 +166,8 @@ public class ChangeRecorder implements AutoCloseable {
           boolean _matched = false;
           if (it instanceof EObjectAddedEChange) {
             _matched = true;
-            EObject _newValue = ((EObjectAddedEChange<EObject>) it).getNewValue();
-            this.outer.existingObjects.add(_newValue);
+            EObject newValue = ((EObjectAddedEChange<EObject>) it).getNewValue();
+            this.outer.existingObjects.add(newValue);
             boolean _matched_1 = false;
             if (it instanceof UpdateReferenceEChange) {
               _matched_1 = true;
@@ -203,8 +203,8 @@ public class ChangeRecorder implements AutoCloseable {
 
     private boolean affectsLoadingResource(final Notification notification) {
       EObject _xifexpression = null;
-      Object _newValue = notification.getNewValue();
-      if ((_newValue instanceof EObject)) {
+      Object newValue = notification.getNewValue();
+      if ((newValue instanceof EObject)) {
         Object _newValue_1 = notification.getNewValue();
         _xifexpression = ((EObject) _newValue_1);
       } else {
@@ -304,9 +304,9 @@ public class ChangeRecorder implements AutoCloseable {
         (EObject affectedObject, EObject addedObject) -> {
       return Boolean.valueOf(this.isCreateChange(affectedObject, addedObject));
     };
-    NotificationToEChangeConverter _notificationToEChangeConverter =
+    NotificationToEChangeConverter notificationToEChangeConverter =
         new NotificationToEChangeConverter(_function);
-    this.converter = _notificationToEChangeConverter;
+    this.converter = notificationToEChangeConverter;
   }
 
   private boolean isCreateChange(final EObject affectedObject, final EObject addedObject) {

--- a/composite/src/main/java/tools/vitruv/change/composite/recording/ChangeRecorder.java
+++ b/composite/src/main/java/tools/vitruv/change/composite/recording/ChangeRecorder.java
@@ -67,8 +67,8 @@ public class ChangeRecorder implements AutoCloseable {
     }
 
     private void handleAdaptersForResourceAndResourceSetChanges(final Notification notification) {
-      if (((notification.getNotifier() instanceof ResourceSet) &&
-          (notification.getFeatureID(ResourceSet.class) == ResourceSet.RESOURCE_SET__RESOURCES))) {
+      if (((notification.getNotifier() instanceof ResourceSet)
+          && (notification.getFeatureID(ResourceSet.class) == ResourceSet.RESOURCE_SET__RESOURCES))) {
         int _eventType = notification.getEventType();
         switch (_eventType) {
           case Notification.ADD:
@@ -88,20 +88,20 @@ public class ChangeRecorder implements AutoCloseable {
       final Object feature = _feature;
       boolean _matched = false;
       if (feature instanceof EReference) {
-        boolean _isContainment = ((EReference) feature).isContainment();
-        if (_isContainment) {
+        boolean isContainment = ((EReference) feature).isContainment();
+        if (isContainment) {
           _matched = true;
         }
       }
       if (!_matched) {
-        if (((notification.getNotifier() instanceof Resource) &&
-            (notification.getFeatureID(Resource.class) == Resource.RESOURCE__CONTENTS))) {
+        if (((notification.getNotifier() instanceof Resource)
+            && (notification.getFeatureID(Resource.class) == Resource.RESOURCE__CONTENTS))) {
           _matched = true;
         }
       }
       if (!_matched) {
-        if (((notification.getNotifier() instanceof ResourceSet) &&
-            (notification.getFeatureID(ResourceSet.class) == ResourceSet.RESOURCE_SET__RESOURCES))) {
+        if (((notification.getNotifier() instanceof ResourceSet)
+            && (notification.getFeatureID(ResourceSet.class) == ResourceSet.RESOURCE_SET__RESOURCES))) {
           _matched = true;
         }
       }
@@ -136,8 +136,8 @@ public class ChangeRecorder implements AutoCloseable {
         }
       }
       if (!_matched) {
-        if (((notification.getNotifier() instanceof Resource) &&
-            (notification.getFeatureID(Resource.class) == Resource.RESOURCE__IS_LOADED))) {
+        if (((notification.getNotifier() instanceof Resource)
+            && (notification.getFeatureID(Resource.class) == Resource.RESOURCE__IS_LOADED))) {
           _matched = true;
           Object _notifier = notification.getNotifier();
           this.finishLoadingResource(((Resource) _notifier));
@@ -168,8 +168,9 @@ public class ChangeRecorder implements AutoCloseable {
             boolean _matched_1 = false;
             if (it instanceof UpdateReferenceEChange) {
               _matched_1 = true;
-              EObject _affectedElement = ((UpdateReferenceEChange<EObject>) it).getAffectedElement();
-              this.outer.existingObjects.add(_affectedElement);
+              EObject affectedElement =
+                  ((UpdateReferenceEChange<EObject>) it).getAffectedElement();
+              this.outer.existingObjects.add(affectedElement);
             }
           }
         };
@@ -228,8 +229,8 @@ public class ChangeRecorder implements AutoCloseable {
         Object _notifier_1 = notification.getNotifier();
         final Resource resource = ((Resource) _notifier_1);
         final ResourceSet resourceSet = resource.getResourceSet();
-        return (((!resource.isLoaded()) && (resourceSet != null)) &&
-            resourceSet.getURIConverter().exists(resource.getURI(), Map.of()));
+        return (((!resource.isLoaded()) && (resourceSet != null))
+            && resourceSet.getURIConverter().exists(resource.getURI(), Map.of()));
       } else {
         return false;
       }
@@ -304,8 +305,8 @@ public class ChangeRecorder implements AutoCloseable {
 
   private boolean isCreateChange(final EObject affectedObject, final EObject addedObject) {
     boolean create = ((addedObject != null) && (!this.existingObjects.contains(addedObject)));
-    create = (create && (((addedObject.eResource() == null) || (affectedObject == null)) ||
-        Objects.equals(addedObject.eResource(), affectedObject.eResource())));
+    create = (create && (((addedObject.eResource() == null) || (affectedObject == null))
+        || Objects.equals(addedObject.eResource(), affectedObject.eResource())));
     if (create) {
       this.existingObjects.add(addedObject);
     }
@@ -492,7 +493,7 @@ public class ChangeRecorder implements AutoCloseable {
     return this.isRecording;
   }
 
-  private static void _recursively(final ResourceSet resourceSet,
+  private static void recursivelyInternal(final ResourceSet resourceSet,
       final Function<Notifier, Boolean> action) {
     Boolean _apply = action.apply(resourceSet);
     if ((_apply).booleanValue()) {
@@ -503,7 +504,7 @@ public class ChangeRecorder implements AutoCloseable {
     }
   }
 
-  private static void _recursively(final Resource resource,
+  private static void recursivelyInternal(final Resource resource,
       final Function<Notifier, Boolean> action) {
     Boolean _apply = action.apply(resource);
     if ((_apply).booleanValue()) {
@@ -514,7 +515,7 @@ public class ChangeRecorder implements AutoCloseable {
     }
   }
 
-  private static void _recursively(final EObject object, final Function<Notifier, Boolean> action) {
+  private static void recursivelyInternal(final EObject object, final Function<Notifier, Boolean> action) {
     Boolean _apply = action.apply(object);
     if ((_apply).booleanValue()) {
       for (final TreeIterator<Notifier> properContents = EcoreUtil.<Notifier>getAllProperContents(
@@ -587,15 +588,15 @@ public class ChangeRecorder implements AutoCloseable {
   private static void recursively(final Notifier object, final Function<Notifier, Boolean> action) {
     if (object instanceof EObject
         && action != null) {
-      _recursively((EObject) object, action);
+      recursivelyInternal((EObject) object, action);
       return;
     } else if (object instanceof Resource
         && action != null) {
-      _recursively((Resource) object, action);
+      recursivelyInternal((Resource) object, action);
       return;
     } else if (object instanceof ResourceSet
         && action != null) {
-      _recursively((ResourceSet) object, action);
+      recursivelyInternal((ResourceSet) object, action);
       return;
     } else {
       throw new IllegalArgumentException("Unhandled parameter types: " +


### PR DESCRIPTION
Description: SonarCloud warning regarding the high cognitive complexity (30) of the postprocessRemovals method in ChangeRecorder.java (Issue #395).

Changes:

Extracted logic from the monolithic postprocessRemovals method into two new, focused helper methods: findRemovedElements and appendDeleteChanges.
Replaced synthetic Xtend-generated variable assignments (_matched, _isEmpty) with cleaner native Java constructs.
Drastically lowered the cognitive complexity of the involved methods to comply with SonarCloud's upper limit.