### PR TITLE
cognitive score on the getStringRepresentation method reduced

### DIFF
--- a/composite/pom.xml
+++ b/composite/pom.xml
@@ -26,6 +26,21 @@
   </build>
 
   <dependencies>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
     <!-- project compile dependencies -->
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/composite/src/main/java/tools/vitruv/change/composite/description/impl/TransactionalChangeImpl.java
+++ b/composite/src/main/java/tools/vitruv/change/composite/description/impl/TransactionalChangeImpl.java
@@ -351,72 +351,90 @@ public class TransactionalChangeImpl<Element extends Object> implements Transact
   }
 
   private CharSequence getStringRepresentation(final EChange<?> change) {
-    boolean _matched = false;
     if (change instanceof InsertRootEObject) {
-      _matched=true;
-      return "insert " + ((InsertRootEObject<?>)change).getNewValue() + " at " + ((InsertRootEObject<?>)change).getUri() + " (index " + ((InsertRootEObject<?>)change).getIndex() + ")";
+      return getInsertRootEObjectString((InsertRootEObject<?>) change);
     }
-    if (!_matched) {
-      if (change instanceof RemoveRootEObject) {
-        _matched=true;
-        return "remove " + ((RemoveRootEObject<?>)change).getOldValue() + " from " + ((RemoveRootEObject<?>)change).getUri() + " (index " + ((RemoveRootEObject<?>)change).getIndex() + ")";
-      }
+    if (change instanceof RemoveRootEObject) {
+      return getRemoveRootEObjectString((RemoveRootEObject<?>) change);
     }
-    if (!_matched) {
-      if (change instanceof CreateEObject) {
-        _matched=true;
-        return "create " + ((CreateEObject<?>)change).getAffectedElement();
-      }
+    if (change instanceof CreateEObject) {
+      return "create " + ((CreateEObject<?>) change).getAffectedElement();
     }
-    if (!_matched) {
-      if (change instanceof DeleteEObject) {
-        _matched=true;
-        return "delete " + ((DeleteEObject<?>)change).getAffectedElement();
-      }
+    if (change instanceof DeleteEObject) {
+      return "delete " + ((DeleteEObject<?>) change).getAffectedElement();
     }
-    if (!_matched) {
-      if (change instanceof UnsetFeature) {
-        _matched=true;
-        return this.getAffectedFeatureString(((FeatureEChange<?, ?>)change)) + " = ∅";
-      }
+    if (change instanceof UnsetFeature) {
+      return getAffectedFeatureString((FeatureEChange<?, ?>) change) + " = ∅";
     }
-    if (!_matched) {
-      if (change instanceof ReplaceSingleValuedEAttribute) {
-        _matched=true;
-        return this.getAffectedFeatureString(((FeatureEChange<?, ?>)change)) + " = " + ((ReplaceSingleValuedEAttribute<?, ?>)change).getNewValue() + " (was " + ((ReplaceSingleValuedEAttribute<?, ?>)change).getOldValue() + ")";
-      }
+    if (change instanceof ReplaceSingleValuedEAttribute) {
+      return getReplaceSingleValuedEAttributeString((ReplaceSingleValuedEAttribute<?, ?>) change);
     }
-    if (!_matched) {
-      if (change instanceof ReplaceSingleValuedEReference) {
-        _matched=true;
-        return this.getAffectedFeatureString(((FeatureEChange<?, ?>)change)) + " = " + ((ReplaceSingleValuedEReference<?>)change).getNewValue() + " (was " + ((ReplaceSingleValuedEReference<?>)change).getOldValue() + ")";
-      }
+    if (change instanceof ReplaceSingleValuedEReference) {
+      return getReplaceSingleValuedEReferenceString((ReplaceSingleValuedEReference<?>) change);
     }
-    if (!_matched) {
-      if (change instanceof InsertEAttributeValue) {
-        _matched=true;
-        return this.getAffectedFeatureString(((FeatureEChange<?, ?>)change)) + " += " + ((InsertEAttributeValue<?, ?>)change).getNewValue() + " (index " + ((InsertEAttributeValue<?, ?>)change).getIndex() + ")";
-      }
+    if (change instanceof InsertEAttributeValue) {
+      return getInsertEAttributeValueString((InsertEAttributeValue<?, ?>) change);
     }
-    if (!_matched) {
-      if (change instanceof InsertEReference) {
-        _matched=true;
-        return this.getAffectedFeatureString(((FeatureEChange<?, ?>)change)) + " += " + ((InsertEReference<?>)change).getNewValue() + " (index " + ((InsertEReference<?>)change).getIndex() + ")";
-      }
+    if (change instanceof InsertEReference) {
+      return getInsertEReferenceString((InsertEReference<?>) change);
     }
-    if (!_matched) {
-      if (change instanceof RemoveEAttributeValue) {
-        _matched=true;
-        return this.getAffectedFeatureString(((FeatureEChange<?, ?>)change)) + " -= " + ((RemoveEAttributeValue<?, ?>)change).getOldValue() + " (index " + ((RemoveEAttributeValue<?, ?>)change).getIndex() + ")";
-      }
+    if (change instanceof RemoveEAttributeValue) {
+      return getRemoveEAttributeValueString((RemoveEAttributeValue<?, ?>) change);
     }
-    if (!_matched) {
-      if (change instanceof RemoveEReference) {
-        _matched=true;
-        return this.getAffectedFeatureString(((FeatureEChange<?, ?>)change)) + " -= " + ((RemoveEReference<?>)change).getOldValue() + " (index " + ((RemoveEReference<?>)change).getIndex() + ")";
-      }
+    if (change instanceof RemoveEReference) {
+      return getRemoveEReferenceString((RemoveEReference<?>) change);
     }
     return null;
+  }
+
+  private CharSequence getInsertRootEObjectString(final InsertRootEObject<?> change) {
+    return "insert " + change.getNewValue()
+            + " at " + change.getUri()
+            + " (index " + change.getIndex() + ")";
+  }
+
+  private CharSequence getRemoveRootEObjectString(final RemoveRootEObject<?> change) {
+    return "remove " + change.getOldValue()
+            + " from " + change.getUri()
+            + " (index " + change.getIndex() + ")";
+  }
+
+  private CharSequence getReplaceSingleValuedEAttributeString(
+          final ReplaceSingleValuedEAttribute<?, ?> change) {
+    return getAffectedFeatureString(change)
+            + " = " + change.getNewValue()
+            + " (was " + change.getOldValue() + ")";
+  }
+
+  private CharSequence getReplaceSingleValuedEReferenceString(
+          final ReplaceSingleValuedEReference<?> change) {
+    return getAffectedFeatureString(change)
+            + " = " + change.getNewValue()
+            + " (was " + change.getOldValue() + ")";
+  }
+
+  private CharSequence getInsertEAttributeValueString(final InsertEAttributeValue<?, ?> change) {
+    return getAffectedFeatureString(change)
+            + " += " + change.getNewValue()
+            + " (index " + change.getIndex() + ")";
+  }
+
+  private CharSequence getInsertEReferenceString(final InsertEReference<?> change) {
+    return getAffectedFeatureString(change)
+            + " += " + change.getNewValue()
+            + " (index " + change.getIndex() + ")";
+  }
+
+  private CharSequence getRemoveEAttributeValueString(final RemoveEAttributeValue<?, ?> change) {
+    return getAffectedFeatureString(change)
+            + " -= " + change.getOldValue()
+            + " (index " + change.getIndex() + ")";
+  }
+
+  private CharSequence getRemoveEReferenceString(final RemoveEReference<?> change) {
+    return getAffectedFeatureString(change)
+            + " -= " + change.getOldValue()
+            + " (index " + change.getIndex() + ")";
   }
 
   private CharSequence getAffectedFeatureString(final FeatureEChange<?, ?> change) {

--- a/composite/src/main/java/tools/vitruv/change/composite/description/impl/TransactionalChangeImpl.java
+++ b/composite/src/main/java/tools/vitruv/change/composite/description/impl/TransactionalChangeImpl.java
@@ -350,6 +350,9 @@ public class TransactionalChangeImpl<Element extends Object> implements Transact
     }
   }
 
+  private static final String INDEX_PREFIX = " (index ";
+  private static final String WAS_PREFIX = " (was ";
+
   private CharSequence getStringRepresentation(final EChange<?> change) {
     if (change instanceof InsertRootEObject) {
       return getInsertRootEObjectString((InsertRootEObject<?>) change);
@@ -390,51 +393,51 @@ public class TransactionalChangeImpl<Element extends Object> implements Transact
   private CharSequence getInsertRootEObjectString(final InsertRootEObject<?> change) {
     return "insert " + change.getNewValue()
             + " at " + change.getUri()
-            + " (index " + change.getIndex() + ")";
+            + INDEX_PREFIX  + change.getIndex() + ")";
   }
 
   private CharSequence getRemoveRootEObjectString(final RemoveRootEObject<?> change) {
     return "remove " + change.getOldValue()
             + " from " + change.getUri()
-            + " (index " + change.getIndex() + ")";
+            + INDEX_PREFIX  + change.getIndex() + ")";
   }
 
   private CharSequence getReplaceSingleValuedEAttributeString(
           final ReplaceSingleValuedEAttribute<?, ?> change) {
     return getAffectedFeatureString(change)
             + " = " + change.getNewValue()
-            + " (was " + change.getOldValue() + ")";
+            + WAS_PREFIX + change.getOldValue() + ")";
   }
 
   private CharSequence getReplaceSingleValuedEReferenceString(
           final ReplaceSingleValuedEReference<?> change) {
     return getAffectedFeatureString(change)
             + " = " + change.getNewValue()
-            + " (was " + change.getOldValue() + ")";
+            + WAS_PREFIX + change.getOldValue() + ")";
   }
 
   private CharSequence getInsertEAttributeValueString(final InsertEAttributeValue<?, ?> change) {
     return getAffectedFeatureString(change)
             + " += " + change.getNewValue()
-            + " (index " + change.getIndex() + ")";
+            + INDEX_PREFIX  + change.getIndex() + ")";
   }
 
   private CharSequence getInsertEReferenceString(final InsertEReference<?> change) {
     return getAffectedFeatureString(change)
             + " += " + change.getNewValue()
-            + " (index " + change.getIndex() + ")";
+            + INDEX_PREFIX  + change.getIndex() + ")";
   }
 
   private CharSequence getRemoveEAttributeValueString(final RemoveEAttributeValue<?, ?> change) {
     return getAffectedFeatureString(change)
             + " -= " + change.getOldValue()
-            + " (index " + change.getIndex() + ")";
+            + INDEX_PREFIX  + change.getIndex() + ")";
   }
 
   private CharSequence getRemoveEReferenceString(final RemoveEReference<?> change) {
     return getAffectedFeatureString(change)
             + " -= " + change.getOldValue()
-            + " (index " + change.getIndex() + ")";
+            + INDEX_PREFIX  + change.getIndex() + ")";
   }
 
   private CharSequence getAffectedFeatureString(final FeatureEChange<?, ?> change) {

--- a/composite/src/test/java/tools/vitruv/change/composite/description/impl/TransactionalChangeImplTest.java
+++ b/composite/src/test/java/tools/vitruv/change/composite/description/impl/TransactionalChangeImplTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
+
 import org.eclipse.emf.ecore.EAttribute;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EReference;
@@ -25,217 +26,219 @@ import tools.vitruv.change.atomic.feature.reference.ReplaceSingleValuedEReferenc
 import tools.vitruv.change.atomic.root.InsertRootEObject;
 import tools.vitruv.change.atomic.root.RemoveRootEObject;
 
-/** Unit tests for {@link TransactionalChangeImpl}. */
+/**
+ * Unit tests for {@link TransactionalChangeImpl}.
+ */
 class TransactionalChangeImplTest {
 
-    private static final String URI = "http://test.com/resource";
-    private static final String FEATURE_NAME = "testFeature";
+  private static final String URI = "http://test.com/resource";
+  private static final String FEATURE_NAME = "testFeature";
 
-    private EObject affectedElement;
-    private EObject newValue;
-    private EObject oldValue;
+  private EObject affectedElement;
+  private EObject newValue;
+  private EObject oldValue;
 
-    @BeforeEach
-    void setUp() {
-        affectedElement = mock(EObject.class);
-        newValue = mock(EObject.class);
-        oldValue = mock(EObject.class);
-    }
+  @BeforeEach
+  void setUp() {
+    affectedElement = mock(EObject.class);
+    newValue = mock(EObject.class);
+    oldValue = mock(EObject.class);
+  }
 
-    // empty
+  // empty
 
-    @Test
-    void toStringEmptyChange() {
-        TransactionalChangeImpl<EObject> change = new TransactionalChangeImpl<>(List.of());
+  @Test
+  void toStringEmptyChange() {
+    TransactionalChangeImpl<EObject> change = new TransactionalChangeImpl<>(List.of());
 
-        assertEquals("TransactionalChangeImpl (empty)", change.toString());
-    }
+    assertEquals("TransactionalChangeImpl (empty)", change.toString());
+  }
 
-    // root changes
+  // root changes
 
-    @Test
-    void toStringInsertRootEObject() {
-        InsertRootEObject<EObject> eChange = mock(InsertRootEObject.class);
-        when(eChange.getNewValue()).thenReturn(newValue);
-        when(eChange.getUri()).thenReturn(URI);
-        when(eChange.getIndex()).thenReturn(0);
+  @Test
+  void toStringInsertRootEObject() {
+    InsertRootEObject<EObject> eChange = mock(InsertRootEObject.class);
+    when(eChange.getNewValue()).thenReturn(newValue);
+    when(eChange.getUri()).thenReturn(URI);
+    when(eChange.getIndex()).thenReturn(0);
 
-        String result = new TransactionalChangeImpl<>(List.of(eChange)).toString();
+    String result = new TransactionalChangeImpl<>(List.of(eChange)).toString();
 
-        assertTrue(result.contains("insert " + newValue + " at " + URI + " (index 0)"));
-    }
+    assertTrue(result.contains("insert " + newValue + " at " + URI + " (index 0)"));
+  }
 
-    @Test
-    void toStringRemoveRootEObject() {
-        RemoveRootEObject<EObject> eChange = mock(RemoveRootEObject.class);
-        when(eChange.getOldValue()).thenReturn(oldValue);
-        when(eChange.getUri()).thenReturn(URI);
-        when(eChange.getIndex()).thenReturn(1);
+  @Test
+  void toStringRemoveRootEObject() {
+    RemoveRootEObject<EObject> eChange = mock(RemoveRootEObject.class);
+    when(eChange.getOldValue()).thenReturn(oldValue);
+    when(eChange.getUri()).thenReturn(URI);
+    when(eChange.getIndex()).thenReturn(1);
 
-        String result = new TransactionalChangeImpl<>(List.of(eChange)).toString();
+    String result = new TransactionalChangeImpl<>(List.of(eChange)).toString();
 
-        assertTrue(result.contains("remove " + oldValue + " from " + URI + " (index 1)"));
-    }
+    assertTrue(result.contains("remove " + oldValue + " from " + URI + " (index 1)"));
+  }
 
-    // EObject existence changes
+  // EObject existence changes
 
-    @Test
-    void toStringCreateEObject() {
-        CreateEObject<EObject> eChange = mock(CreateEObject.class);
-        when(eChange.getAffectedElement()).thenReturn(affectedElement);
+  @Test
+  void toStringCreateEObject() {
+    CreateEObject<EObject> eChange = mock(CreateEObject.class);
+    when(eChange.getAffectedElement()).thenReturn(affectedElement);
 
-        String result = new TransactionalChangeImpl<>(List.of(eChange)).toString();
+    String result = new TransactionalChangeImpl<>(List.of(eChange)).toString();
 
-        assertTrue(result.contains("create " + affectedElement));
-    }
+    assertTrue(result.contains("create " + affectedElement));
+  }
 
-    @Test
-    void toStringDeleteEObject() {
-        DeleteEObject<EObject> eChange = mock(DeleteEObject.class);
-        when(eChange.getAffectedElement()).thenReturn(affectedElement);
+  @Test
+  void toStringDeleteEObject() {
+    DeleteEObject<EObject> eChange = mock(DeleteEObject.class);
+    when(eChange.getAffectedElement()).thenReturn(affectedElement);
 
-        String result = new TransactionalChangeImpl<>(List.of(eChange)).toString();
+    String result = new TransactionalChangeImpl<>(List.of(eChange)).toString();
 
-        assertTrue(result.contains("delete " + affectedElement));
-    }
+    assertTrue(result.contains("delete " + affectedElement));
+  }
 
-    // feature changes
+  // feature changes
 
-    @Test
-    void toStringUnsetFeature() {
-        UnsetFeature<EObject, ?> eChange = mock(UnsetFeature.class);
-        EStructuralFeature feature = mock(EStructuralFeature.class);
-        when(feature.getName()).thenReturn(FEATURE_NAME);
-        when(eChange.getAffectedElement()).thenReturn(affectedElement);
-        when((EStructuralFeature) eChange.getAffectedFeature()).thenReturn(feature);
+  @Test
+  void toStringUnsetFeature() {
+    UnsetFeature<EObject, ?> eChange = mock(UnsetFeature.class);
+    EStructuralFeature feature = mock(EStructuralFeature.class);
+    when(feature.getName()).thenReturn(FEATURE_NAME);
+    when(eChange.getAffectedElement()).thenReturn(affectedElement);
+    when((EStructuralFeature) eChange.getAffectedFeature()).thenReturn(feature);
 
-        String result = new TransactionalChangeImpl<>(List.of(eChange)).toString();
+    String result = new TransactionalChangeImpl<>(List.of(eChange)).toString();
 
-        assertTrue(result.contains(affectedElement + "." + FEATURE_NAME + " = ∅"));
-    }
+    assertTrue(result.contains(affectedElement + "." + FEATURE_NAME + " = ∅"));
+  }
 
-    @Test
-    void toStringReplaceSingleValuedEAttribute() {
-        ReplaceSingleValuedEAttribute<EObject, Object> eChange = mock(ReplaceSingleValuedEAttribute.class);
-        EAttribute feature = mock(EAttribute.class);
-        when(feature.getName()).thenReturn(FEATURE_NAME);
-        when(eChange.getAffectedElement()).thenReturn(affectedElement);
-        when(eChange.getAffectedFeature()).thenReturn(feature);
-        when(eChange.getNewValue()).thenReturn(newValue);
-        when(eChange.getOldValue()).thenReturn(oldValue);
+  @Test
+  void toStringReplaceSingleValuedEAttribute() {
+    ReplaceSingleValuedEAttribute<EObject, Object> eChange = mock(ReplaceSingleValuedEAttribute.class);
+    EAttribute feature = mock(EAttribute.class);
+    when(feature.getName()).thenReturn(FEATURE_NAME);
+    when(eChange.getAffectedElement()).thenReturn(affectedElement);
+    when(eChange.getAffectedFeature()).thenReturn(feature);
+    when(eChange.getNewValue()).thenReturn(newValue);
+    when(eChange.getOldValue()).thenReturn(oldValue);
 
-        String result = new TransactionalChangeImpl<>(List.of(eChange)).toString();
+    String result = new TransactionalChangeImpl<>(List.of(eChange)).toString();
 
-        assertTrue(result.contains(
-                affectedElement + "." + FEATURE_NAME + " = " + newValue + " (was " + oldValue + ")"));
-    }
+    assertTrue(result.contains(
+        affectedElement + "." + FEATURE_NAME + " = " + newValue + " (was " + oldValue + ")"));
+  }
 
-    @Test
-    void toStringReplaceSingleValuedEReference() {
-        ReplaceSingleValuedEReference<EObject> eChange = mock(ReplaceSingleValuedEReference.class);
-        EReference feature = mock(EReference.class);
-        when(feature.getName()).thenReturn(FEATURE_NAME);
-        when(eChange.getAffectedElement()).thenReturn(affectedElement);
-        when(eChange.getAffectedFeature()).thenReturn(feature);
-        when(eChange.getNewValue()).thenReturn(newValue);
-        when(eChange.getOldValue()).thenReturn(oldValue);
+  @Test
+  void toStringReplaceSingleValuedEReference() {
+    ReplaceSingleValuedEReference<EObject> eChange = mock(ReplaceSingleValuedEReference.class);
+    EReference feature = mock(EReference.class);
+    when(feature.getName()).thenReturn(FEATURE_NAME);
+    when(eChange.getAffectedElement()).thenReturn(affectedElement);
+    when(eChange.getAffectedFeature()).thenReturn(feature);
+    when(eChange.getNewValue()).thenReturn(newValue);
+    when(eChange.getOldValue()).thenReturn(oldValue);
 
-        String result = new TransactionalChangeImpl<>(List.of(eChange)).toString();
+    String result = new TransactionalChangeImpl<>(List.of(eChange)).toString();
 
-        assertTrue(result.contains(
-                affectedElement + "." + FEATURE_NAME + " = " + newValue + " (was " + oldValue + ")"));
-    }
+    assertTrue(result.contains(
+        affectedElement + "." + FEATURE_NAME + " = " + newValue + " (was " + oldValue + ")"));
+  }
 
-    @Test
-    void toStringInsertEAttributeValue() {
-        InsertEAttributeValue<EObject, Object> eChange = mock(InsertEAttributeValue.class);
-        EAttribute feature = mock(EAttribute.class);
-        when(feature.getName()).thenReturn(FEATURE_NAME);
-        when(eChange.getAffectedElement()).thenReturn(affectedElement);
-        when(eChange.getAffectedFeature()).thenReturn(feature);
-        when(eChange.getNewValue()).thenReturn(newValue);
-        when(eChange.getIndex()).thenReturn(2);
+  @Test
+  void toStringInsertEAttributeValue() {
+    InsertEAttributeValue<EObject, Object> eChange = mock(InsertEAttributeValue.class);
+    EAttribute feature = mock(EAttribute.class);
+    when(feature.getName()).thenReturn(FEATURE_NAME);
+    when(eChange.getAffectedElement()).thenReturn(affectedElement);
+    when(eChange.getAffectedFeature()).thenReturn(feature);
+    when(eChange.getNewValue()).thenReturn(newValue);
+    when(eChange.getIndex()).thenReturn(2);
 
-        String result = new TransactionalChangeImpl<>(List.of(eChange)).toString();
+    String result = new TransactionalChangeImpl<>(List.of(eChange)).toString();
 
-        assertTrue(result.contains(
-                affectedElement + "." + FEATURE_NAME + " += " + newValue + " (index 2)"));
-    }
+    assertTrue(result.contains(
+        affectedElement + "." + FEATURE_NAME + " += " + newValue + " (index 2)"));
+  }
 
-    @Test
-    void toStringInsertEReference() {
-        InsertEReference<EObject> eChange = mock(InsertEReference.class);
-        EReference feature = mock(EReference.class);
-        when(feature.getName()).thenReturn(FEATURE_NAME);
-        when(eChange.getAffectedElement()).thenReturn(affectedElement);
-        when(eChange.getAffectedFeature()).thenReturn(feature);
-        when(eChange.getNewValue()).thenReturn(newValue);
-        when(eChange.getIndex()).thenReturn(3);
+  @Test
+  void toStringInsertEReference() {
+    InsertEReference<EObject> eChange = mock(InsertEReference.class);
+    EReference feature = mock(EReference.class);
+    when(feature.getName()).thenReturn(FEATURE_NAME);
+    when(eChange.getAffectedElement()).thenReturn(affectedElement);
+    when(eChange.getAffectedFeature()).thenReturn(feature);
+    when(eChange.getNewValue()).thenReturn(newValue);
+    when(eChange.getIndex()).thenReturn(3);
 
-        String result = new TransactionalChangeImpl<>(List.of(eChange)).toString();
+    String result = new TransactionalChangeImpl<>(List.of(eChange)).toString();
 
-        assertTrue(result.contains(
-                affectedElement + "." + FEATURE_NAME + " += " + newValue + " (index 3)"));
-    }
+    assertTrue(result.contains(
+        affectedElement + "." + FEATURE_NAME + " += " + newValue + " (index 3)"));
+  }
 
-    @Test
-    void toStringRemoveEAttributeValue() {
-        RemoveEAttributeValue<EObject, Object> eChange = mock(RemoveEAttributeValue.class);
-        EAttribute feature = mock(EAttribute.class);
-        when(feature.getName()).thenReturn(FEATURE_NAME);
-        when(eChange.getAffectedElement()).thenReturn(affectedElement);
-        when(eChange.getAffectedFeature()).thenReturn(feature);
-        when(eChange.getOldValue()).thenReturn(oldValue);
-        when(eChange.getIndex()).thenReturn(4);
+  @Test
+  void toStringRemoveEAttributeValue() {
+    RemoveEAttributeValue<EObject, Object> eChange = mock(RemoveEAttributeValue.class);
+    EAttribute feature = mock(EAttribute.class);
+    when(feature.getName()).thenReturn(FEATURE_NAME);
+    when(eChange.getAffectedElement()).thenReturn(affectedElement);
+    when(eChange.getAffectedFeature()).thenReturn(feature);
+    when(eChange.getOldValue()).thenReturn(oldValue);
+    when(eChange.getIndex()).thenReturn(4);
 
-        String result = new TransactionalChangeImpl<>(List.of(eChange)).toString();
+    String result = new TransactionalChangeImpl<>(List.of(eChange)).toString();
 
-        assertTrue(result.contains(
-                affectedElement + "." + FEATURE_NAME + " -= " + oldValue + " (index 4)"));
-    }
+    assertTrue(result.contains(
+        affectedElement + "." + FEATURE_NAME + " -= " + oldValue + " (index 4)"));
+  }
 
-    @Test
-    void toStringRemoveEReference() {
-        RemoveEReference<EObject> eChange = mock(RemoveEReference.class);
-        EReference feature = mock(EReference.class);
-        when(feature.getName()).thenReturn(FEATURE_NAME);
-        when(eChange.getAffectedElement()).thenReturn(affectedElement);
-        when(eChange.getAffectedFeature()).thenReturn(feature);
-        when(eChange.getOldValue()).thenReturn(oldValue);
-        when(eChange.getIndex()).thenReturn(5);
+  @Test
+  void toStringRemoveEReference() {
+    RemoveEReference<EObject> eChange = mock(RemoveEReference.class);
+    EReference feature = mock(EReference.class);
+    when(feature.getName()).thenReturn(FEATURE_NAME);
+    when(eChange.getAffectedElement()).thenReturn(affectedElement);
+    when(eChange.getAffectedFeature()).thenReturn(feature);
+    when(eChange.getOldValue()).thenReturn(oldValue);
+    when(eChange.getIndex()).thenReturn(5);
 
-        String result = new TransactionalChangeImpl<>(List.of(eChange)).toString();
+    String result = new TransactionalChangeImpl<>(List.of(eChange)).toString();
 
-        assertTrue(result.contains(
-                affectedElement + "." + FEATURE_NAME + " -= " + oldValue + " (index 5)"));
-    }
+    assertTrue(result.contains(
+        affectedElement + "." + FEATURE_NAME + " -= " + oldValue + " (index 5)"));
+  }
 
-    // multiple changes
+  // multiple changes
 
-    @Test
-    void toStringWithMultipleChanges() {
-        InsertRootEObject<EObject> insert = mock(InsertRootEObject.class);
-        when(insert.getNewValue()).thenReturn(newValue);
-        when(insert.getUri()).thenReturn(URI);
-        when(insert.getIndex()).thenReturn(0);
+  @Test
+  void toStringWithMultipleChanges() {
+    InsertRootEObject<EObject> insert = mock(InsertRootEObject.class);
+    when(insert.getNewValue()).thenReturn(newValue);
+    when(insert.getUri()).thenReturn(URI);
+    when(insert.getIndex()).thenReturn(0);
 
-        DeleteEObject<EObject> delete = mock(DeleteEObject.class);
-        when(delete.getAffectedElement()).thenReturn(affectedElement);
+    DeleteEObject<EObject> delete = mock(DeleteEObject.class);
+    when(delete.getAffectedElement()).thenReturn(affectedElement);
 
-        String result = new TransactionalChangeImpl<>(List.of(insert, delete)).toString();
+    String result = new TransactionalChangeImpl<>(List.of(insert, delete)).toString();
 
-        assertTrue(result.contains("insert " + newValue + " at " + URI + " (index 0)"));
-        assertTrue(result.contains("delete " + affectedElement));
-    }
+    assertTrue(result.contains("insert " + newValue + " at " + URI + " (index 0)"));
+    assertTrue(result.contains("delete " + affectedElement));
+  }
 
-    // unknown change type
+  // unknown change type
 
-    @Test
-    void toStringUnknownChangeTypeReturnsNull() {
-        EChange<EObject> eChange = mock(EChange.class);
+  @Test
+  void toStringUnknownChangeTypeReturnsNull() {
+    EChange<EObject> eChange = mock(EChange.class);
 
-        String result = new TransactionalChangeImpl<>(List.of(eChange)).toString();
+    String result = new TransactionalChangeImpl<>(List.of(eChange)).toString();
 
-        assertTrue(result.contains("null"));
-    }
+    assertTrue(result.contains("null"));
+  }
 }

--- a/composite/src/test/java/tools/vitruv/change/composite/description/impl/TransactionalChangeImplTest.java
+++ b/composite/src/test/java/tools/vitruv/change/composite/description/impl/TransactionalChangeImplTest.java
@@ -6,7 +6,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
-
 import org.eclipse.emf.ecore.EAttribute;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EReference;
@@ -119,7 +118,8 @@ class TransactionalChangeImplTest {
 
   @Test
   void toStringReplaceSingleValuedEAttribute() {
-    ReplaceSingleValuedEAttribute<EObject, Object> eChange = mock(ReplaceSingleValuedEAttribute.class);
+    ReplaceSingleValuedEAttribute<EObject, Object> eChange =
+        mock(ReplaceSingleValuedEAttribute.class);
     EAttribute feature = mock(EAttribute.class);
     when(feature.getName()).thenReturn(FEATURE_NAME);
     when(eChange.getAffectedElement()).thenReturn(affectedElement);

--- a/composite/src/test/java/tools/vitruv/change/composite/description/impl/TransactionalChangeImplTest.java
+++ b/composite/src/test/java/tools/vitruv/change/composite/description/impl/TransactionalChangeImplTest.java
@@ -1,0 +1,241 @@
+package tools.vitruv.change.composite.description.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import org.eclipse.emf.ecore.EAttribute;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.EReference;
+import org.eclipse.emf.ecore.EStructuralFeature;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import tools.vitruv.change.atomic.EChange;
+import tools.vitruv.change.atomic.eobject.CreateEObject;
+import tools.vitruv.change.atomic.eobject.DeleteEObject;
+import tools.vitruv.change.atomic.feature.UnsetFeature;
+import tools.vitruv.change.atomic.feature.attribute.InsertEAttributeValue;
+import tools.vitruv.change.atomic.feature.attribute.RemoveEAttributeValue;
+import tools.vitruv.change.atomic.feature.attribute.ReplaceSingleValuedEAttribute;
+import tools.vitruv.change.atomic.feature.reference.InsertEReference;
+import tools.vitruv.change.atomic.feature.reference.RemoveEReference;
+import tools.vitruv.change.atomic.feature.reference.ReplaceSingleValuedEReference;
+import tools.vitruv.change.atomic.root.InsertRootEObject;
+import tools.vitruv.change.atomic.root.RemoveRootEObject;
+
+/** Unit tests for {@link TransactionalChangeImpl}. */
+class TransactionalChangeImplTest {
+
+    private static final String URI = "http://test.com/resource";
+    private static final String FEATURE_NAME = "testFeature";
+
+    private EObject affectedElement;
+    private EObject newValue;
+    private EObject oldValue;
+
+    @BeforeEach
+    void setUp() {
+        affectedElement = mock(EObject.class);
+        newValue = mock(EObject.class);
+        oldValue = mock(EObject.class);
+    }
+
+    // empty
+
+    @Test
+    void toStringEmptyChange() {
+        TransactionalChangeImpl<EObject> change = new TransactionalChangeImpl<>(List.of());
+
+        assertEquals("TransactionalChangeImpl (empty)", change.toString());
+    }
+
+    // root changes
+
+    @Test
+    void toStringInsertRootEObject() {
+        InsertRootEObject<EObject> eChange = mock(InsertRootEObject.class);
+        when(eChange.getNewValue()).thenReturn(newValue);
+        when(eChange.getUri()).thenReturn(URI);
+        when(eChange.getIndex()).thenReturn(0);
+
+        String result = new TransactionalChangeImpl<>(List.of(eChange)).toString();
+
+        assertTrue(result.contains("insert " + newValue + " at " + URI + " (index 0)"));
+    }
+
+    @Test
+    void toStringRemoveRootEObject() {
+        RemoveRootEObject<EObject> eChange = mock(RemoveRootEObject.class);
+        when(eChange.getOldValue()).thenReturn(oldValue);
+        when(eChange.getUri()).thenReturn(URI);
+        when(eChange.getIndex()).thenReturn(1);
+
+        String result = new TransactionalChangeImpl<>(List.of(eChange)).toString();
+
+        assertTrue(result.contains("remove " + oldValue + " from " + URI + " (index 1)"));
+    }
+
+    // EObject existence changes
+
+    @Test
+    void toStringCreateEObject() {
+        CreateEObject<EObject> eChange = mock(CreateEObject.class);
+        when(eChange.getAffectedElement()).thenReturn(affectedElement);
+
+        String result = new TransactionalChangeImpl<>(List.of(eChange)).toString();
+
+        assertTrue(result.contains("create " + affectedElement));
+    }
+
+    @Test
+    void toStringDeleteEObject() {
+        DeleteEObject<EObject> eChange = mock(DeleteEObject.class);
+        when(eChange.getAffectedElement()).thenReturn(affectedElement);
+
+        String result = new TransactionalChangeImpl<>(List.of(eChange)).toString();
+
+        assertTrue(result.contains("delete " + affectedElement));
+    }
+
+    // feature changes
+
+    @Test
+    void toStringUnsetFeature() {
+        UnsetFeature<EObject, ?> eChange = mock(UnsetFeature.class);
+        EStructuralFeature feature = mock(EStructuralFeature.class);
+        when(feature.getName()).thenReturn(FEATURE_NAME);
+        when(eChange.getAffectedElement()).thenReturn(affectedElement);
+        when((EStructuralFeature) eChange.getAffectedFeature()).thenReturn(feature);
+
+        String result = new TransactionalChangeImpl<>(List.of(eChange)).toString();
+
+        assertTrue(result.contains(affectedElement + "." + FEATURE_NAME + " = ∅"));
+    }
+
+    @Test
+    void toStringReplaceSingleValuedEAttribute() {
+        ReplaceSingleValuedEAttribute<EObject, Object> eChange = mock(ReplaceSingleValuedEAttribute.class);
+        EAttribute feature = mock(EAttribute.class);
+        when(feature.getName()).thenReturn(FEATURE_NAME);
+        when(eChange.getAffectedElement()).thenReturn(affectedElement);
+        when(eChange.getAffectedFeature()).thenReturn(feature);
+        when(eChange.getNewValue()).thenReturn(newValue);
+        when(eChange.getOldValue()).thenReturn(oldValue);
+
+        String result = new TransactionalChangeImpl<>(List.of(eChange)).toString();
+
+        assertTrue(result.contains(
+                affectedElement + "." + FEATURE_NAME + " = " + newValue + " (was " + oldValue + ")"));
+    }
+
+    @Test
+    void toStringReplaceSingleValuedEReference() {
+        ReplaceSingleValuedEReference<EObject> eChange = mock(ReplaceSingleValuedEReference.class);
+        EReference feature = mock(EReference.class);
+        when(feature.getName()).thenReturn(FEATURE_NAME);
+        when(eChange.getAffectedElement()).thenReturn(affectedElement);
+        when(eChange.getAffectedFeature()).thenReturn(feature);
+        when(eChange.getNewValue()).thenReturn(newValue);
+        when(eChange.getOldValue()).thenReturn(oldValue);
+
+        String result = new TransactionalChangeImpl<>(List.of(eChange)).toString();
+
+        assertTrue(result.contains(
+                affectedElement + "." + FEATURE_NAME + " = " + newValue + " (was " + oldValue + ")"));
+    }
+
+    @Test
+    void toStringInsertEAttributeValue() {
+        InsertEAttributeValue<EObject, Object> eChange = mock(InsertEAttributeValue.class);
+        EAttribute feature = mock(EAttribute.class);
+        when(feature.getName()).thenReturn(FEATURE_NAME);
+        when(eChange.getAffectedElement()).thenReturn(affectedElement);
+        when(eChange.getAffectedFeature()).thenReturn(feature);
+        when(eChange.getNewValue()).thenReturn(newValue);
+        when(eChange.getIndex()).thenReturn(2);
+
+        String result = new TransactionalChangeImpl<>(List.of(eChange)).toString();
+
+        assertTrue(result.contains(
+                affectedElement + "." + FEATURE_NAME + " += " + newValue + " (index 2)"));
+    }
+
+    @Test
+    void toStringInsertEReference() {
+        InsertEReference<EObject> eChange = mock(InsertEReference.class);
+        EReference feature = mock(EReference.class);
+        when(feature.getName()).thenReturn(FEATURE_NAME);
+        when(eChange.getAffectedElement()).thenReturn(affectedElement);
+        when(eChange.getAffectedFeature()).thenReturn(feature);
+        when(eChange.getNewValue()).thenReturn(newValue);
+        when(eChange.getIndex()).thenReturn(3);
+
+        String result = new TransactionalChangeImpl<>(List.of(eChange)).toString();
+
+        assertTrue(result.contains(
+                affectedElement + "." + FEATURE_NAME + " += " + newValue + " (index 3)"));
+    }
+
+    @Test
+    void toStringRemoveEAttributeValue() {
+        RemoveEAttributeValue<EObject, Object> eChange = mock(RemoveEAttributeValue.class);
+        EAttribute feature = mock(EAttribute.class);
+        when(feature.getName()).thenReturn(FEATURE_NAME);
+        when(eChange.getAffectedElement()).thenReturn(affectedElement);
+        when(eChange.getAffectedFeature()).thenReturn(feature);
+        when(eChange.getOldValue()).thenReturn(oldValue);
+        when(eChange.getIndex()).thenReturn(4);
+
+        String result = new TransactionalChangeImpl<>(List.of(eChange)).toString();
+
+        assertTrue(result.contains(
+                affectedElement + "." + FEATURE_NAME + " -= " + oldValue + " (index 4)"));
+    }
+
+    @Test
+    void toStringRemoveEReference() {
+        RemoveEReference<EObject> eChange = mock(RemoveEReference.class);
+        EReference feature = mock(EReference.class);
+        when(feature.getName()).thenReturn(FEATURE_NAME);
+        when(eChange.getAffectedElement()).thenReturn(affectedElement);
+        when(eChange.getAffectedFeature()).thenReturn(feature);
+        when(eChange.getOldValue()).thenReturn(oldValue);
+        when(eChange.getIndex()).thenReturn(5);
+
+        String result = new TransactionalChangeImpl<>(List.of(eChange)).toString();
+
+        assertTrue(result.contains(
+                affectedElement + "." + FEATURE_NAME + " -= " + oldValue + " (index 5)"));
+    }
+
+    // multiple changes
+
+    @Test
+    void toStringWithMultipleChanges() {
+        InsertRootEObject<EObject> insert = mock(InsertRootEObject.class);
+        when(insert.getNewValue()).thenReturn(newValue);
+        when(insert.getUri()).thenReturn(URI);
+        when(insert.getIndex()).thenReturn(0);
+
+        DeleteEObject<EObject> delete = mock(DeleteEObject.class);
+        when(delete.getAffectedElement()).thenReturn(affectedElement);
+
+        String result = new TransactionalChangeImpl<>(List.of(insert, delete)).toString();
+
+        assertTrue(result.contains("insert " + newValue + " at " + URI + " (index 0)"));
+        assertTrue(result.contains("delete " + affectedElement));
+    }
+
+    // unknown change type
+
+    @Test
+    void toStringUnknownChangeTypeReturnsNull() {
+        EChange<EObject> eChange = mock(EChange.class);
+
+        String result = new TransactionalChangeImpl<>(List.of(eChange)).toString();
+
+        assertTrue(result.contains("null"));
+    }
+}


### PR DESCRIPTION
Reduce Cognitive Complexity of getStringRepresentation

What changed

- Replaced the mutable **_matched** flag pattern with simple early return statements
- Extracted each string-building branch into its own dedicated helper method
- Split the method into 9 focused methods
