### PR TITLE
Make changeDataSetTable transient (SonarCloud java:S1948)

### DIFF
--- a/testutils/changevisualization/src/main/java/tools/vitruv/change/testutils/changevisualization/ui/ChangesTab.java
+++ b/testutils/changevisualization/src/main/java/tools/vitruv/change/testutils/changevisualization/ui/ChangesTab.java
@@ -32,7 +32,7 @@ public class ChangesTab extends JPanel
    * The table responsible for the display of the general changeDataSet
    * information.
    */
-  private ChangeDataSetTableView changeDataSetTable;
+  private transient ChangeDataSetTableView changeDataSetTable;
 
   /** The affectedEOject id to highlight. */
   private String highlightID;


### PR DESCRIPTION

Resolves the SonarCloud finding **java:S1948** ("Fields in a Serializable class
should be either transient or serializable") on the `changeDataSetTable` field
of `ChangesTab`.

`ChangesTab extends JPanel`, so it is `Serializable` and declares a
`serialVersionUID`. The field is typed as the interface `ChangeDataSetTableView`,
which does **not** extend `Serializable`. Even though the concrete
implementation (`ChangeDataSetTable`) is itself a `JPanel` and thus serializable,
Sonar cannot prove serializability through the interface type and flags the field.

Both classes document that serialization "will never be used" (the
`serialVersionUID`s exist only to silence warnings), so the field is marked
`transient` — the first of the two options named in the issue. This avoids
forcing `Serializable` onto every future implementer of `ChangeDataSetTableView`.