### PR TITLE
Argument order has changed according to the method definition

### DIFF
--- a/atomic/src/test/java/tools/vitruv/change/atomic/command/internal/RemoveAtCommandTest.java
+++ b/atomic/src/test/java/tools/vitruv/change/atomic/command/internal/RemoveAtCommandTest.java
@@ -91,7 +91,7 @@ class RemoveAtCommandTest extends CommandTest {
     RemoveAtCommand removeAtCommand = CommandTest.<RemoveAtCommand>assertIsInstanceOf(command, RemoveAtCommand.class);
     Assertions.assertSame(removeAtCommand.getOwnerList(), list);
     Assertions.assertTrue(removeAtCommand.getCollection().contains(value));
-    Assertions.assertEquals(removeAtCommand.getCollection().size(), 1);
+    Assertions.assertEquals(1, removeAtCommand.getCollection().size());
     Assertions.assertEquals(removeAtCommand.getIndex(), index);
     return removeAtCommand;
   }

--- a/atomic/src/test/java/tools/vitruv/change/atomic/compound/ExplicitUnsetEAttributeTest.java
+++ b/atomic/src/test/java/tools/vitruv/change/atomic/compound/ExplicitUnsetEAttributeTest.java
@@ -130,11 +130,11 @@ class ExplicitUnsetEAttributeTest extends EChangeTest {
     boolean _isMany = this.affectedFeature.isMany();
     boolean _not = (!_isMany);
     if (_not) {
-      Assertions.assertEquals(this.affectedEObject.eGet(this.affectedFeature), ExplicitUnsetEAttributeTest.OLD_VALUE);
+      Assertions.assertEquals(ExplicitUnsetEAttributeTest.OLD_VALUE, this.affectedEObject.eGet(this.affectedFeature));
     } else {
-      Assertions.assertEquals(this.attributeContent.get(0), ExplicitUnsetEAttributeTest.OLD_VALUE);
-      Assertions.assertEquals(this.attributeContent.get(1), ExplicitUnsetEAttributeTest.OLD_VALUE_2);
-      Assertions.assertEquals(this.attributeContent.get(2), ExplicitUnsetEAttributeTest.OLD_VALUE_3);
+      Assertions.assertEquals(ExplicitUnsetEAttributeTest.OLD_VALUE, this.attributeContent.get(0));
+      Assertions.assertEquals(ExplicitUnsetEAttributeTest.OLD_VALUE_2, this.attributeContent.get(1));
+      Assertions.assertEquals(ExplicitUnsetEAttributeTest.OLD_VALUE_3, this.attributeContent.get(2));
     }
   }
 

--- a/atomic/src/test/java/tools/vitruv/change/atomic/compound/ExplicitUnsetEAttributeTest.java
+++ b/atomic/src/test/java/tools/vitruv/change/atomic/compound/ExplicitUnsetEAttributeTest.java
@@ -130,11 +130,23 @@ class ExplicitUnsetEAttributeTest extends EChangeTest {
     boolean _isMany = this.affectedFeature.isMany();
     boolean _not = (!_isMany);
     if (_not) {
-      Assertions.assertEquals(ExplicitUnsetEAttributeTest.OLD_VALUE, this.affectedEObject.eGet(this.affectedFeature));
+      Assertions.assertEquals(
+              ExplicitUnsetEAttributeTest.OLD_VALUE,
+              this.affectedEObject.eGet(this.affectedFeature)
+      );
     } else {
-      Assertions.assertEquals(ExplicitUnsetEAttributeTest.OLD_VALUE, this.attributeContent.get(0));
-      Assertions.assertEquals(ExplicitUnsetEAttributeTest.OLD_VALUE_2, this.attributeContent.get(1));
-      Assertions.assertEquals(ExplicitUnsetEAttributeTest.OLD_VALUE_3, this.attributeContent.get(2));
+      Assertions.assertEquals(
+              ExplicitUnsetEAttributeTest.OLD_VALUE,
+              this.attributeContent.get(0)
+      );
+      Assertions.assertEquals(
+              ExplicitUnsetEAttributeTest.OLD_VALUE_2,
+              this.attributeContent.get(1)
+      );
+      Assertions.assertEquals(
+              ExplicitUnsetEAttributeTest.OLD_VALUE_3,
+              this.attributeContent.get(2)
+      );
     }
   }
 


### PR DESCRIPTION
JUnit .assertEquals() method is defined as having the inputs in the (expectedValue, actualValue) order. This commit modified it according to the 5 issues on SonarCube.