### PR TITLE
Refactor eChange handling to reduce cognitive complexity

### DIFF
--- a/composite/src/main/java/tools/vitruv/change/composite/description/impl/TransactionalChangeImpl.java
+++ b/composite/src/main/java/tools/vitruv/change/composite/description/impl/TransactionalChangeImpl.java
@@ -159,41 +159,41 @@ public class TransactionalChangeImpl<Element extends Object> implements Transact
 
   private static Set<EObject> getAffectedAndReferencedEObjects(final EChange<?> eChange) {
     if (eChange instanceof UpdateAttributeEChange) {
-      return Set.<EObject>of(((UpdateAttributeEChange<EObject>)eChange).getAffectedElement());
+      return Set.<EObject>of(((UpdateAttributeEChange<EObject>) eChange).getAffectedElement());
     }
 
     if (eChange instanceof ReplaceSingleValuedEReference) {
       return TransactionalChangeImpl.<EObject>setOfNotNull(
-              ((ReplaceSingleValuedEReference<EObject>)eChange).getAffectedElement(),
-              ((ReplaceSingleValuedEReference<EObject>)eChange).getOldValue(),
-              ((ReplaceSingleValuedEReference<EObject>)eChange).getNewValue()
+              ((ReplaceSingleValuedEReference<EObject>) eChange).getAffectedElement(),
+              ((ReplaceSingleValuedEReference<EObject>) eChange).getOldValue(),
+              ((ReplaceSingleValuedEReference<EObject>) eChange).getNewValue()
       );
     }
 
     if (eChange instanceof InsertEReference) {
       return Set.<EObject>of(
-              ((InsertEReference<EObject>)eChange).getAffectedElement(),
-              ((InsertEReference<EObject>)eChange).getNewValue()
+              ((InsertEReference<EObject>) eChange).getAffectedElement(),
+              ((InsertEReference<EObject>) eChange).getNewValue()
       );
     }
 
     if (eChange instanceof RemoveEReference) {
       return Set.<EObject>of(
-              ((RemoveEReference<EObject>)eChange).getAffectedElement(),
-              ((RemoveEReference<EObject>)eChange).getOldValue()
+              ((RemoveEReference<EObject>) eChange).getAffectedElement(),
+              ((RemoveEReference<EObject>) eChange).getOldValue()
       );
     }
 
     if (eChange instanceof EObjectExistenceEChange) {
-      return Set.<EObject>of(((EObjectExistenceEChange<EObject>)eChange).getAffectedElement());
+      return Set.<EObject>of(((EObjectExistenceEChange<EObject>) eChange).getAffectedElement());
     }
 
     if (eChange instanceof InsertRootEObject) {
-      return Set.<EObject>of(((InsertRootEObject<EObject>)eChange).getNewValue());
+      return Set.<EObject>of(((InsertRootEObject<EObject>) eChange).getNewValue());
     }
 
     if (eChange instanceof RemoveRootEObject) {
-      return Set.<EObject>of(((RemoveRootEObject<EObject>)eChange).getOldValue());
+      return Set.<EObject>of(((RemoveRootEObject<EObject>) eChange).getOldValue());
     }
     return null;
   }

--- a/composite/src/main/java/tools/vitruv/change/composite/description/impl/TransactionalChangeImpl.java
+++ b/composite/src/main/java/tools/vitruv/change/composite/description/impl/TransactionalChangeImpl.java
@@ -158,49 +158,44 @@ public class TransactionalChangeImpl<Element extends Object> implements Transact
   }
 
   private static Set<EObject> getAffectedAndReferencedEObjects(final EChange<?> eChange) {
-    Set<EObject> _switchResult = null;
-    boolean _matched = false;
     if (eChange instanceof UpdateAttributeEChange) {
-      _matched=true;
-      _switchResult = Set.<EObject>of(((UpdateAttributeEChange<EObject>)eChange).getAffectedElement());
+      return Set.<EObject>of(((UpdateAttributeEChange<EObject>)eChange).getAffectedElement());
     }
-    if (!_matched) {
-      if (eChange instanceof ReplaceSingleValuedEReference) {
-        _matched=true;
-        _switchResult = TransactionalChangeImpl.<EObject>setOfNotNull(((ReplaceSingleValuedEReference<EObject>)eChange).getAffectedElement(), ((ReplaceSingleValuedEReference<EObject>)eChange).getOldValue(), ((ReplaceSingleValuedEReference<EObject>)eChange).getNewValue());
-      }
+
+    if (eChange instanceof ReplaceSingleValuedEReference) {
+      return TransactionalChangeImpl.<EObject>setOfNotNull(
+              ((ReplaceSingleValuedEReference<EObject>)eChange).getAffectedElement(),
+              ((ReplaceSingleValuedEReference<EObject>)eChange).getOldValue(),
+              ((ReplaceSingleValuedEReference<EObject>)eChange).getNewValue()
+      );
     }
-    if (!_matched) {
-      if (eChange instanceof InsertEReference) {
-        _matched=true;
-        _switchResult = Set.<EObject>of(((InsertEReference<EObject>)eChange).getAffectedElement(), ((InsertEReference<EObject>)eChange).getNewValue());
-      }
+
+    if (eChange instanceof InsertEReference) {
+      return Set.<EObject>of(
+              ((InsertEReference<EObject>)eChange).getAffectedElement(),
+              ((InsertEReference<EObject>)eChange).getNewValue()
+      );
     }
-    if (!_matched) {
-      if (eChange instanceof RemoveEReference) {
-        _matched=true;
-        _switchResult = Set.<EObject>of(((RemoveEReference<EObject>)eChange).getAffectedElement(), ((RemoveEReference<EObject>)eChange).getOldValue());
-      }
+
+    if (eChange instanceof RemoveEReference) {
+      return Set.<EObject>of(
+              ((RemoveEReference<EObject>)eChange).getAffectedElement(),
+              ((RemoveEReference<EObject>)eChange).getOldValue()
+      );
     }
-    if (!_matched) {
-      if (eChange instanceof EObjectExistenceEChange) {
-        _matched=true;
-        _switchResult = Set.<EObject>of(((EObjectExistenceEChange<EObject>)eChange).getAffectedElement());
-      }
+
+    if (eChange instanceof EObjectExistenceEChange) {
+      return Set.<EObject>of(((EObjectExistenceEChange<EObject>)eChange).getAffectedElement());
     }
-    if (!_matched) {
-      if (eChange instanceof InsertRootEObject) {
-        _matched=true;
-        _switchResult = Set.<EObject>of(((InsertRootEObject<EObject>)eChange).getNewValue());
-      }
+
+    if (eChange instanceof InsertRootEObject) {
+      return Set.<EObject>of(((InsertRootEObject<EObject>)eChange).getNewValue());
     }
-    if (!_matched) {
-      if (eChange instanceof RemoveRootEObject) {
-        _matched=true;
-        _switchResult = Set.<EObject>of(((RemoveRootEObject<EObject>)eChange).getOldValue());
-      }
+
+    if (eChange instanceof RemoveRootEObject) {
+      return Set.<EObject>of(((RemoveRootEObject<EObject>)eChange).getOldValue());
     }
-    return _switchResult;
+    return null;
   }
 
   @Override

--- a/composite/src/main/java/tools/vitruv/change/composite/description/impl/TransactionalChangeImpl.java
+++ b/composite/src/main/java/tools/vitruv/change/composite/description/impl/TransactionalChangeImpl.java
@@ -195,7 +195,7 @@ public class TransactionalChangeImpl<Element extends Object> implements Transact
     if (eChange instanceof RemoveRootEObject) {
       return Set.<EObject>of(((RemoveRootEObject<EObject>) eChange).getOldValue());
     }
-    return null;
+    return Set.of();
   }
 
   @Override

--- a/composite/src/test/java/tools/vitruv/change/composite/description/impl/TransactionalChangeImplTest.java
+++ b/composite/src/test/java/tools/vitruv/change/composite/description/impl/TransactionalChangeImplTest.java
@@ -6,6 +6,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
+import java.util.Set;
+
 import org.eclipse.emf.ecore.EAttribute;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EReference;
@@ -15,10 +17,12 @@ import org.junit.jupiter.api.Test;
 import tools.vitruv.change.atomic.EChange;
 import tools.vitruv.change.atomic.eobject.CreateEObject;
 import tools.vitruv.change.atomic.eobject.DeleteEObject;
+import tools.vitruv.change.atomic.eobject.EObjectExistenceEChange;
 import tools.vitruv.change.atomic.feature.UnsetFeature;
 import tools.vitruv.change.atomic.feature.attribute.InsertEAttributeValue;
 import tools.vitruv.change.atomic.feature.attribute.RemoveEAttributeValue;
 import tools.vitruv.change.atomic.feature.attribute.ReplaceSingleValuedEAttribute;
+import tools.vitruv.change.atomic.feature.attribute.UpdateAttributeEChange;
 import tools.vitruv.change.atomic.feature.reference.InsertEReference;
 import tools.vitruv.change.atomic.feature.reference.RemoveEReference;
 import tools.vitruv.change.atomic.feature.reference.ReplaceSingleValuedEReference;
@@ -240,5 +244,96 @@ class TransactionalChangeImplTest {
     String result = new TransactionalChangeImpl<>(List.of(eChange)).toString();
 
     assertTrue(result.contains("null"));
+  }
+
+  @Test
+  void getAffectedAndReferencedEObjectsForUpdateAttributeEChange() {
+    UpdateAttributeEChange<EObject> eChange = mock(UpdateAttributeEChange.class);
+    when(eChange.getAffectedElement()).thenReturn(affectedElement);
+
+    Set<EObject> result =
+            new TransactionalChangeImpl<>(List.of(eChange)).getAffectedAndReferencedEObjects();
+
+    assertEquals(Set.of(affectedElement), result);
+  }
+
+  @Test
+  void getAffectedAndReferencedEObjectsForReplaceSingleValuedEReference() {
+    ReplaceSingleValuedEReference<EObject> eChange = mock(ReplaceSingleValuedEReference.class);
+    when(eChange.getAffectedElement()).thenReturn(affectedElement);
+    when(eChange.getOldValue()).thenReturn(oldValue);
+    when(eChange.getNewValue()).thenReturn(newValue);
+
+    Set<EObject> result =
+            new TransactionalChangeImpl<>(List.of(eChange)).getAffectedAndReferencedEObjects();
+
+    assertEquals(Set.of(affectedElement, oldValue, newValue), result);
+  }
+
+  @Test
+  void getAffectedAndReferencedEObjectsForInsertEReference() {
+    InsertEReference<EObject> eChange = mock(InsertEReference.class);
+    when(eChange.getAffectedElement()).thenReturn(affectedElement);
+    when(eChange.getNewValue()).thenReturn(newValue);
+
+    Set<EObject> result =
+            new TransactionalChangeImpl<>(List.of(eChange)).getAffectedAndReferencedEObjects();
+
+    assertEquals(Set.of(affectedElement, newValue), result);
+  }
+
+  @Test
+  void getAffectedAndReferencedEObjectsForRemoveEReference() {
+    RemoveEReference<EObject> eChange = mock(RemoveEReference.class);
+    when(eChange.getAffectedElement()).thenReturn(affectedElement);
+    when(eChange.getOldValue()).thenReturn(oldValue);
+
+    Set<EObject> result =
+            new TransactionalChangeImpl<>(List.of(eChange)).getAffectedAndReferencedEObjects();
+
+    assertEquals(Set.of(affectedElement, oldValue), result);
+  }
+
+  @Test
+  void getAffectedAndReferencedEObjectsForEObjectExistenceEChange() {
+    EObjectExistenceEChange<EObject> eChange = mock(EObjectExistenceEChange.class);
+    when(eChange.getAffectedElement()).thenReturn(affectedElement);
+
+    Set<EObject> result =
+            new TransactionalChangeImpl<>(List.of(eChange)).getAffectedAndReferencedEObjects();
+
+    assertEquals(Set.of(affectedElement), result);
+  }
+
+  @Test
+  void getAffectedAndReferencedEObjectsForInsertRootEObject() {
+    InsertRootEObject<EObject> eChange = mock(InsertRootEObject.class);
+    when(eChange.getNewValue()).thenReturn(newValue);
+
+    Set<EObject> result =
+            new TransactionalChangeImpl<>(List.of(eChange)).getAffectedAndReferencedEObjects();
+
+    assertEquals(Set.of(newValue), result);
+  }
+
+  @Test
+  void getAffectedAndReferencedEObjectsForRemoveRootEObject() {
+    RemoveRootEObject<EObject> eChange = mock(RemoveRootEObject.class);
+    when(eChange.getOldValue()).thenReturn(oldValue);
+
+    Set<EObject> result =
+            new TransactionalChangeImpl<>(List.of(eChange)).getAffectedAndReferencedEObjects();
+
+    assertEquals(Set.of(oldValue), result);
+  }
+
+  @Test
+  void getAffectedAndReferencedEObjectsForUnknownChangeTypeReturnsEmptySet() {
+    EChange<EObject> eChange = mock(EChange.class);
+
+    Set<EObject> result =
+            new TransactionalChangeImpl<>(List.of(eChange)).getAffectedAndReferencedEObjects();
+
+    assertTrue(result.isEmpty());
   }
 }


### PR DESCRIPTION
Cognitive complexity is reduced by adding early returns into method, which helped us to remove the nested if statements.