### PR TITLE
Return Optional from predefined confirmation and notification results

### DIFF
--- a/interaction/pom.xml
+++ b/interaction/pom.xml
@@ -53,5 +53,12 @@
       <artifactId>tools.vitruv.change.p2wrappers.javautils</artifactId>
       <version>${project.version}</version>
     </dependency>
+
+    <!-- test dependencies -->
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/interaction/src/main/java/tools/vitruv/change/interaction/impl/PredefinedInteractionMatcher.java
+++ b/interaction/src/main/java/tools/vitruv/change/interaction/impl/PredefinedInteractionMatcher.java
@@ -3,6 +3,7 @@ package tools.vitruv.change.interaction.impl;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
@@ -64,28 +65,28 @@ public class PredefinedInteractionMatcher {
     return inputToReuse;
   }
 
-  public Boolean getNotificationResult(final String message) {
+  public Optional<Boolean> getNotificationResult(final String message) {
     final Iterable<ConfirmationUserInteraction> inputToReuseCandidates = this
         .<ConfirmationUserInteraction>getMatchingInput(message, ConfirmationUserInteraction.class);
     boolean _isEmpty = Iterables.isEmpty(inputToReuseCandidates);
     if (_isEmpty) {
-      return null;
+      return Optional.empty();
     }
     final ConfirmationUserInteraction inputToReuse = inputToReuseCandidates.iterator().next();
     this.userInteractions.remove(inputToReuse);
-    return Boolean.valueOf(true);
+    return Optional.of(Boolean.TRUE);
   }
 
-  public Boolean getConfirmationResult(final String message) {
+  public Optional<Boolean> getConfirmationResult(final String message) {
     final Iterable<ConfirmationUserInteraction> inputToReuseCandidates = this
         .<ConfirmationUserInteraction>getMatchingInput(message, ConfirmationUserInteraction.class);
     boolean _isEmpty = Iterables.isEmpty(inputToReuseCandidates);
     if (_isEmpty) {
-      return null;
+      return Optional.empty();
     }
     final ConfirmationUserInteraction inputToReuse = inputToReuseCandidates.iterator().next();
     this.userInteractions.remove(inputToReuse);
-    return Boolean.valueOf(inputToReuse.isConfirmed());
+    return Optional.of(Boolean.valueOf(inputToReuse.isConfirmed()));
   }
 
   public String getTextInputResult(final String message) {

--- a/interaction/src/main/java/tools/vitruv/change/interaction/impl/PredefinedInteractionMatcher.java
+++ b/interaction/src/main/java/tools/vitruv/change/interaction/impl/PredefinedInteractionMatcher.java
@@ -65,6 +65,12 @@ public class PredefinedInteractionMatcher {
     return inputToReuse;
   }
 
+  /**
+   * Returns the predefined notification result for the given message, if one is available.
+   *
+   * @param message the message to find a matching predefined notification for
+   * @return present if a predefined interaction matched, empty otherwise
+   */
   public Optional<Boolean> getNotificationResult(final String message) {
     final Iterable<ConfirmationUserInteraction> inputToReuseCandidates = this
         .<ConfirmationUserInteraction>getMatchingInput(message, ConfirmationUserInteraction.class);
@@ -77,6 +83,12 @@ public class PredefinedInteractionMatcher {
     return Optional.of(Boolean.TRUE);
   }
 
+  /**
+   * Returns the predefined confirmation result for the given message, if one is available.
+   *
+   * @param message the message to find a matching predefined confirmation for
+   * @return the confirmation result, or empty if no input was predefined
+   */
   public Optional<Boolean> getConfirmationResult(final String message) {
     final Iterable<ConfirmationUserInteraction> inputToReuseCandidates = this
         .<ConfirmationUserInteraction>getMatchingInput(message, ConfirmationUserInteraction.class);

--- a/interaction/src/main/java/tools/vitruv/change/interaction/impl/PredefinedInteractionResultProviderImpl.java
+++ b/interaction/src/main/java/tools/vitruv/change/interaction/impl/PredefinedInteractionResultProviderImpl.java
@@ -48,7 +48,7 @@ public class PredefinedInteractionResultProviderImpl implements PredefinedIntera
   public boolean getConfirmationInteractionResult(final UserInteractionOptions.WindowModality windowModality,
       final String title, final String message, final String positiveDecisionText, final String negativeDecisionText,
       final String cancelDecisionText) {
-    Boolean result = this.predefinedInteractionMatcher.getConfirmationResult(message);
+    Boolean result = this.predefinedInteractionMatcher.getConfirmationResult(message).orElse(null);
     if (((result == null) && (this.fallback != null))) {
       result = Boolean.valueOf(this.fallback.getConfirmationInteractionResult(windowModality, title, message,
           positiveDecisionText, negativeDecisionText, cancelDecisionText));
@@ -64,8 +64,9 @@ public class PredefinedInteractionResultProviderImpl implements PredefinedIntera
   public void getNotificationInteractionResult(final UserInteractionOptions.WindowModality windowModality,
       final String title, final String message, final String positiveDecisionText,
       final UserInteractionOptions.NotificationType notificationType) {
-    final Boolean result = this.predefinedInteractionMatcher.getNotificationResult(message);
-    if (((result == null) && (this.fallback != null))) {
+    final boolean noPredefinedResult =
+        this.predefinedInteractionMatcher.getNotificationResult(message).isEmpty();
+    if ((noPredefinedResult && (this.fallback != null))) {
       this.fallback.getNotificationInteractionResult(windowModality, title, message, positiveDecisionText,
           notificationType);
     }

--- a/interaction/src/main/java/tools/vitruv/change/interaction/impl/PredefinedInteractionResultProviderImpl.java
+++ b/interaction/src/main/java/tools/vitruv/change/interaction/impl/PredefinedInteractionResultProviderImpl.java
@@ -1,6 +1,7 @@
 package tools.vitruv.change.interaction.impl;
 
 import java.util.Arrays;
+import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
@@ -48,16 +49,17 @@ public class PredefinedInteractionResultProviderImpl implements PredefinedIntera
   public boolean getConfirmationInteractionResult(final UserInteractionOptions.WindowModality windowModality,
       final String title, final String message, final String positiveDecisionText, final String negativeDecisionText,
       final String cancelDecisionText) {
-    Boolean result = this.predefinedInteractionMatcher.getConfirmationResult(message).orElse(null);
-    if (((result == null) && (this.fallback != null))) {
-      result = Boolean.valueOf(this.fallback.getConfirmationInteractionResult(windowModality, title, message,
-          positiveDecisionText, negativeDecisionText, cancelDecisionText));
+    final Optional<Boolean> predefinedResult =
+        this.predefinedInteractionMatcher.getConfirmationResult(message);
+    if (predefinedResult.isPresent()) {
+      return predefinedResult.get().booleanValue();
     }
-    final Supplier<String> _function = () -> {
-      String _printInteraction = this.printInteraction(title, message);
-      return ("No input given for confirmation:" + _printInteraction);
-    };
-    return (this.<Boolean>ifNullThrow(result, _function)).booleanValue();
+    if (this.fallback == null) {
+      throw new IllegalStateException(
+          "No input given for confirmation:" + this.printInteraction(title, message));
+    }
+    return this.fallback.getConfirmationInteractionResult(windowModality, title, message,
+        positiveDecisionText, negativeDecisionText, cancelDecisionText);
   }
 
   @Override

--- a/interaction/src/test/java/tools/vitruv/change/interaction/impl/PredefinedInteractionMatcherTest.java
+++ b/interaction/src/test/java/tools/vitruv/change/interaction/impl/PredefinedInteractionMatcherTest.java
@@ -1,0 +1,63 @@
+package tools.vitruv.change.interaction.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import tools.vitruv.change.interaction.ConfirmationUserInteraction;
+import tools.vitruv.change.interaction.InteractionFactory;
+
+class PredefinedInteractionMatcherTest {
+  private static final String MESSAGE = "Proceed?";
+
+  private static ConfirmationUserInteraction confirmation(final String message,
+      final boolean confirmed) {
+    final ConfirmationUserInteraction interaction =
+        InteractionFactory.eINSTANCE.createConfirmationUserInteraction();
+    interaction.setMessage(message);
+    interaction.setConfirmed(confirmed);
+    return interaction;
+  }
+
+  @Test
+  void getConfirmationResultReturnsConfirmedValueWhenMatchPresent() {
+    final PredefinedInteractionMatcher matcher = new PredefinedInteractionMatcher();
+    matcher.addInteraction(confirmation(MESSAGE, true));
+    assertEquals(Optional.of(Boolean.TRUE), matcher.getConfirmationResult(MESSAGE));
+  }
+
+  @Test
+  void getConfirmationResultReturnsFalseValueWhenMatchNotConfirmed() {
+    final PredefinedInteractionMatcher matcher = new PredefinedInteractionMatcher();
+    matcher.addInteraction(confirmation(MESSAGE, false));
+    assertEquals(Optional.of(Boolean.FALSE), matcher.getConfirmationResult(MESSAGE));
+  }
+
+  @Test
+  void getConfirmationResultReturnsEmptyWhenNoMatch() {
+    final PredefinedInteractionMatcher matcher = new PredefinedInteractionMatcher();
+    assertTrue(matcher.getConfirmationResult(MESSAGE).isEmpty());
+  }
+
+  @Test
+  void getNotificationResultReturnsPresentWhenMatchPresent() {
+    final PredefinedInteractionMatcher matcher = new PredefinedInteractionMatcher();
+    matcher.addInteraction(confirmation(MESSAGE, false));
+    assertEquals(Optional.of(Boolean.TRUE), matcher.getNotificationResult(MESSAGE));
+  }
+
+  @Test
+  void getNotificationResultReturnsEmptyWhenNoMatch() {
+    final PredefinedInteractionMatcher matcher = new PredefinedInteractionMatcher();
+    assertTrue(matcher.getNotificationResult(MESSAGE).isEmpty());
+  }
+
+  @Test
+  void getConfirmationResultConsumesMatchedInteraction() {
+    final PredefinedInteractionMatcher matcher = new PredefinedInteractionMatcher();
+    matcher.addInteraction(confirmation(MESSAGE, true));
+    assertEquals(Optional.of(Boolean.TRUE), matcher.getConfirmationResult(MESSAGE));
+    assertTrue(matcher.getConfirmationResult(MESSAGE).isEmpty());
+  }
+}


### PR DESCRIPTION
getNotificationResult and getConfirmationResult declared a Boolean return type but returned null when no predefined input matched (SonarCloud java:S2447). Both now return Optional<Boolean> (empty when there is no match), and the only caller, PredefinedInteractionResultProviderImpl, is adapted accordingly while keeping the existing fallback behaviour.

Adds unit tests for PredefinedInteractionMatcher covering the present, absent and consumption paths of both methods.

Closes #429