### PR TITLE
Refactor `NotificationInfo#getDebugString` to reduce complexity

### DIFF
--- a/composite/src/main/java/tools/vitruv/change/composite/recording/NotificationInfo.java
+++ b/composite/src/main/java/tools/vitruv/change/composite/recording/NotificationInfo.java
@@ -280,68 +280,52 @@ class NotificationInfo implements Notification {
    */
   public String getDebugString() {
     final StringBuilder sb = new StringBuilder();
-    boolean isAddEvent = this.isAddEvent();
-    if (isAddEvent) {
-      sb.append("ADD");
-    } else {
-      boolean isSetEvent = this.isSetEvent();
-      if (isSetEvent) {
-        sb.append("SET");
-      } else {
-        boolean isAddManyEvent = this.isAddManyEvent();
-        if (isAddManyEvent) {
-          sb.append("ADDMANY");
-        } else {
-          boolean isRemoveEvent = this.isRemoveEvent();
-          if (isRemoveEvent) {
-            sb.append("REMOVE");
-          } else {
-            boolean isRemoveManyEvent = this.isRemoveManyEvent();
-            if (isRemoveManyEvent) {
-              sb.append("REMOVEMANY");
-            } else {
-              boolean isMoveEvent = this.isMoveEvent();
-              if (isMoveEvent) {
-                sb.append("MOVE");
-              } else {
-                sb.append(this.notification.getEventType());
-              }
-            }
-          }
-        }
-      }
-    }
+    sb.append(this.getEventTypeDebugName());
     sb.append(" val: ").append(this.getValidationMessage());
     Object notifier = this.notification.getNotifier();
     final EObject n = ((EObject) notifier);
     sb.append(" / on: ").append(this.extractName(n));
     sb.append(".");
-    boolean isAttributeNotification = this.isAttributeNotification();
-    if (isAttributeNotification) {
-      sb.append(this.getAttribute().getName());
-    } else {
-      boolean isReferenceNotification = this.isReferenceNotification();
-      if (isReferenceNotification) {
-        sb.append(this.getReference().getName());
-      }
-    }
-    sb.append(" / old: ");
-    Object oldValue = this.getOldValue();
-    if ((oldValue instanceof EObject)) {
-      Object oldValue1 = this.getOldValue();
-      sb.append(this.extractName(((EObject) oldValue1)));
-    } else {
-      sb.append(this.getOldValue());
-    }
-    sb.append(" / new: ");
-    Object newValue = this.getNewValue();
-    if ((newValue instanceof EObject)) {
-      Object newValue1 = this.getNewValue();
-      sb.append(this.extractName(((EObject) newValue1)));
-    } else {
-      sb.append(this.getNewValue());
-    }
+    sb.append(this.getFeatureDebugName());
+    sb.append(" / old: ").append(this.getValueDebugString(this.getOldValue()));
+    sb.append(" / new: ").append(this.getValueDebugString(this.getNewValue()));
     return sb.toString();
+  }
+
+  private String getEventTypeDebugName() {
+    switch (this.notification.getEventType()) {
+      case Notification.ADD:
+        return "ADD";
+      case Notification.SET:
+        return "SET";
+      case Notification.ADD_MANY:
+        return "ADDMANY";
+      case Notification.REMOVE:
+        return "REMOVE";
+      case Notification.REMOVE_MANY:
+        return "REMOVEMANY";
+      case Notification.MOVE:
+        return "MOVE";
+      default:
+        return String.valueOf(this.notification.getEventType());
+    }
+  }
+
+  private String getFeatureDebugName() {
+    if (this.isAttributeNotification()) {
+      return this.getAttribute().getName();
+    }
+    if (this.isReferenceNotification()) {
+      return this.getReference().getName();
+    }
+    return "";
+  }
+
+  private Object getValueDebugString(final Object value) {
+    if ((value instanceof EObject)) {
+      return this.extractName(((EObject) value));
+    }
+    return value;
   }
 
   private String extractName(final EObject o) {

--- a/composite/src/main/java/tools/vitruv/change/composite/recording/NotificationInfo.java
+++ b/composite/src/main/java/tools/vitruv/change/composite/recording/NotificationInfo.java
@@ -322,8 +322,8 @@ class NotificationInfo implements Notification {
   }
 
   private Object getValueDebugString(final Object value) {
-    if ((value instanceof EObject)) {
-      return this.extractName(((EObject) value));
+    if ((value instanceof EObject eObject)) {
+      return this.extractName(eObject);
     }
     return value;
   }

--- a/composite/src/test/java/tools/vitruv/change/composite/recording/NotificationInfoTest.java
+++ b/composite/src/test/java/tools/vitruv/change/composite/recording/NotificationInfoTest.java
@@ -1,0 +1,84 @@
+package tools.vitruv.change.composite.recording;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.stream.Stream;
+import org.eclipse.emf.common.notify.Notification;
+import org.eclipse.emf.ecore.EClass;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.EStructuralFeature;
+import org.eclipse.emf.ecore.EcoreFactory;
+import org.eclipse.emf.ecore.EcorePackage;
+import org.eclipse.emf.ecore.InternalEObject;
+import org.eclipse.emf.ecore.impl.ENotificationImpl;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class NotificationInfoTest {
+  @ParameterizedTest
+  @MethodSource("eventTypeDebugNames")
+  void debugStringIncludesEventTypeName(final int eventType, final String eventTypeName) {
+    final NotificationInfo notificationInfo =
+        new NotificationInfo(
+            notification(
+                eventType, EcorePackage.Literals.ENAMED_ELEMENT__NAME, "before", "after"));
+
+    assertEquals(
+        eventTypeName + " val: null / on: 'Owner'.name / old: before / new: after",
+        notificationInfo.getDebugString());
+  }
+
+  @Test
+  void debugStringIncludesReferenceFeatureNameAndEObjectValues() {
+    final NotificationInfo notificationInfo =
+        new NotificationInfo(
+            notification(
+                Notification.REMOVE,
+                EcorePackage.Literals.ECLASS__ESUPER_TYPES,
+                namedClass("Old"),
+                namedClass("New")));
+
+    assertEquals(
+        "REMOVE val: null / on: 'Owner'.eSuperTypes / old: 'Old' / new: 'New'",
+        notificationInfo.getDebugString());
+  }
+
+  @Test
+  void debugStringLeavesFeatureNameEmptyForNonStructuralFeatureNotifications() {
+    final NotificationInfo notificationInfo =
+        new NotificationInfo(notification(Notification.MOVE, null, "before", "after"));
+
+    assertEquals(
+        "MOVE val: null / on: 'Owner'. / old: before / new: after",
+        notificationInfo.getDebugString());
+  }
+
+  private static Stream<Arguments> eventTypeDebugNames() {
+    return Stream.of(
+        Arguments.of(Notification.ADD, "ADD"),
+        Arguments.of(Notification.SET, "SET"),
+        Arguments.of(Notification.ADD_MANY, "ADDMANY"),
+        Arguments.of(Notification.REMOVE, "REMOVE"),
+        Arguments.of(Notification.REMOVE_MANY, "REMOVEMANY"),
+        Arguments.of(Notification.MOVE, "MOVE"),
+        Arguments.of(Notification.UNSET, String.valueOf(Notification.UNSET)));
+  }
+
+  private static Notification notification(
+      final int eventType,
+      final EStructuralFeature feature,
+      final Object oldValue,
+      final Object newValue) {
+    final EObject notifier = namedClass("Owner");
+    return new ENotificationImpl(
+        ((InternalEObject) notifier), eventType, feature, oldValue, newValue);
+  }
+
+  private static EClass namedClass(final String name) {
+    final EClass eClass = EcoreFactory.eINSTANCE.createEClass();
+    eClass.setName(name);
+    return eClass;
+  }
+}


### PR DESCRIPTION
## Summary

Refactors `NotificationInfo#getDebugString()` to reduce its cognitive complexity below the SonarQube threshold.

The method now delegates event type formatting, feature name resolution, and old/new value formatting to small private helper methods. The debug string output behavior remains unchanged.

Adds focused unit coverage for the debug string formatting paths to satisfy the new-code coverage Quality Gate.

## Validation

- Ran `mvn -pl composite test`
- 158 tests passed