### PR TITLE
Refactor PrintResult combination logic and add coverage

### DIFF
--- a/testutils/core/src/main/java/tools/vitruv/change/testutils/printing/PrintResultExtension.java
+++ b/testutils/core/src/main/java/tools/vitruv/change/testutils/printing/PrintResultExtension.java
@@ -5,73 +5,25 @@ import java.util.function.Supplier;
 
 public final class PrintResultExtension {
   public static PrintResult operator_plus(final PrintResult a, final PrintResult b) {
-    PrintResult _xblockexpression = null;
-    {
-      Preconditions.<PrintResult>checkNotNull(a, "previous result");
-      Preconditions.<PrintResult>checkNotNull(b, "latest result");
-      PrintResult _switchResult = null;
-      if (a != null) {
-        switch (a) {
-          case PRINTED:
-            PrintResult _switchResult_1 = null;
-            if (b != null) {
-              switch (b) {
-                case PRINTED:
-                case PRINTED_NO_OUTPUT:
-                  _switchResult_1 = PrintResult.PRINTED;
-                  break;
-                case NOT_RESPONSIBLE:
-                  throw new IllegalStateException(
-                      "Got " + PrintResult.NOT_RESPONSIBLE + " after " + PrintResult.PRINTED + "!");
-                default:
-                  break;
-              }
-            }
-            _switchResult = _switchResult_1;
-            break;
-          case PRINTED_NO_OUTPUT:
-            PrintResult _switchResult_2 = null;
-            if (b != null) {
-              switch (b) {
-                case PRINTED_NO_OUTPUT:
-                  _switchResult_2 = PrintResult.PRINTED_NO_OUTPUT;
-                  break;
-                case NOT_RESPONSIBLE:
-                  _switchResult_2 = PrintResult.NOT_RESPONSIBLE;
-                  break;
-                case PRINTED:
-                  _switchResult_2 = PrintResult.PRINTED;
-                  break;
-                default:
-                  break;
-              }
-            }
-            _switchResult = _switchResult_2;
-            break;
-          case NOT_RESPONSIBLE:
-            PrintResult _switchResult_3 = null;
-            if (b != null) {
-              switch (b) {
-                case PRINTED:
-                  throw new IllegalStateException(
-                      "Got " + PrintResult.PRINTED + " after " + PrintResult.NOT_RESPONSIBLE + "!");
-                case PRINTED_NO_OUTPUT:
-                case NOT_RESPONSIBLE:
-                  _switchResult_3 = PrintResult.NOT_RESPONSIBLE;
-                  break;
-                default:
-                  break;
-              }
-            }
-            _switchResult = _switchResult_3;
-            break;
-          default:
-            break;
-        }
-      }
-      _xblockexpression = _switchResult;
+    Preconditions.<PrintResult>checkNotNull(a, "previous result");
+    Preconditions.<PrintResult>checkNotNull(b, "latest result");
+
+    if (((a == PrintResult.PRINTED) && (b == PrintResult.NOT_RESPONSIBLE))
+        || ((a == PrintResult.NOT_RESPONSIBLE) && (b == PrintResult.PRINTED))) {
+      throw inconsistentResults(a, b);
     }
-    return _xblockexpression;
+    if ((a == PrintResult.PRINTED) || (b == PrintResult.PRINTED)) {
+      return PrintResult.PRINTED;
+    }
+    if ((a == PrintResult.NOT_RESPONSIBLE) || (b == PrintResult.NOT_RESPONSIBLE)) {
+      return PrintResult.NOT_RESPONSIBLE;
+    }
+    return PrintResult.PRINTED_NO_OUTPUT;
+  }
+
+  private static IllegalStateException inconsistentResults(
+      final PrintResult previousResult, final PrintResult latestResult) {
+    return new IllegalStateException("Got " + latestResult + " after " + previousResult + "!");
   }
 
   public static PrintResult combine(final Iterable<? extends PrintResult> results) {

--- a/testutils/core/src/test/java/tools/vitruv/change/testutils/printing/PrintResultExtensionTest.java
+++ b/testutils/core/src/test/java/tools/vitruv/change/testutils/printing/PrintResultExtensionTest.java
@@ -1,0 +1,62 @@
+package tools.vitruv.change.testutils.printing;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class PrintResultExtensionTest {
+  @ParameterizedTest
+  @MethodSource("validResultCombinations")
+  void combinesValidResults(
+      final PrintResult previousResult,
+      final PrintResult latestResult,
+      final PrintResult expectedResult) {
+    assertEquals(expectedResult, PrintResultExtension.operator_plus(previousResult, latestResult));
+  }
+
+  @ParameterizedTest
+  @MethodSource("inconsistentResultCombinations")
+  void rejectsInconsistentResults(
+      final PrintResult previousResult, final PrintResult latestResult) {
+    final IllegalStateException exception =
+        assertThrows(
+            IllegalStateException.class,
+            () -> PrintResultExtension.operator_plus(previousResult, latestResult));
+
+    assertEquals(
+        "Got " + latestResult + " after " + previousResult + "!", exception.getMessage());
+  }
+
+  private static Stream<Arguments> validResultCombinations() {
+    return Stream.of(
+        Arguments.of(PrintResult.PRINTED, PrintResult.PRINTED, PrintResult.PRINTED),
+        Arguments.of(PrintResult.PRINTED, PrintResult.PRINTED_NO_OUTPUT, PrintResult.PRINTED),
+        Arguments.of(PrintResult.PRINTED_NO_OUTPUT, PrintResult.PRINTED, PrintResult.PRINTED),
+        Arguments.of(
+            PrintResult.PRINTED_NO_OUTPUT,
+            PrintResult.PRINTED_NO_OUTPUT,
+            PrintResult.PRINTED_NO_OUTPUT),
+        Arguments.of(
+            PrintResult.PRINTED_NO_OUTPUT,
+            PrintResult.NOT_RESPONSIBLE,
+            PrintResult.NOT_RESPONSIBLE),
+        Arguments.of(
+            PrintResult.NOT_RESPONSIBLE,
+            PrintResult.PRINTED_NO_OUTPUT,
+            PrintResult.NOT_RESPONSIBLE),
+        Arguments.of(
+            PrintResult.NOT_RESPONSIBLE,
+            PrintResult.NOT_RESPONSIBLE,
+            PrintResult.NOT_RESPONSIBLE));
+  }
+
+  private static Stream<Arguments> inconsistentResultCombinations() {
+    return Stream.of(
+        Arguments.of(PrintResult.PRINTED, PrintResult.NOT_RESPONSIBLE),
+        Arguments.of(PrintResult.NOT_RESPONSIBLE, PrintResult.PRINTED));
+  }
+}


### PR DESCRIPTION
## Summary

Refactors `PrintResultExtension#operator_plus()` to reduce its cognitive complexity below the SonarQube threshold.

The nested switch structure is replaced with simple transition rules for valid `PrintResult` combinations while preserving the existing invalid-transition exceptions.

Adds focused unit coverage for all valid result combinations and the two invalid transitions, so the new code meets the coverage Quality Gate.