### PR TITLE
Document intentionally-empty IPostProcessor hooks in MatchRoots

### DIFF
--- a/testutils/core/src/main/java/tools/vitruv/change/testutils/matchers/ModelDeepEqualityMatcher.java
+++ b/testutils/core/src/main/java/tools/vitruv/change/testutils/matchers/ModelDeepEqualityMatcher.java
@@ -106,18 +106,26 @@ class ModelDeepEqualityMatcher<O extends EObject> extends TypeSafeMatcher<O> {
 
     @Override
     public void postComparison(final Comparison comparison, final Monitor monitor) {
+      // Intentionally empty: matching the two roots only requires the postMatch hook,
+      // so this lifecycle callback of IPostProcessor is deliberately a no-op.
     }
 
     @Override
     public void postConflicts(final Comparison comparison, final Monitor monitor) {
+      // Intentionally empty: matching the two roots only requires the postMatch hook,
+      // so this lifecycle callback of IPostProcessor is deliberately a no-op.
     }
 
     @Override
     public void postDiff(final Comparison comparison, final Monitor monitor) {
+      // Intentionally empty: matching the two roots only requires the postMatch hook,
+      // so this lifecycle callback of IPostProcessor is deliberately a no-op.
     }
 
     @Override
     public void postEquivalences(final Comparison comparison, final Monitor monitor) {
+      // Intentionally empty: matching the two roots only requires the postMatch hook,
+      // so this lifecycle callback of IPostProcessor is deliberately a no-op.
     }
 
     @Override
@@ -159,6 +167,8 @@ class ModelDeepEqualityMatcher<O extends EObject> extends TypeSafeMatcher<O> {
 
     @Override
     public void postRequirements(final Comparison comparison, final Monitor monitor) {
+      // Intentionally empty: matching the two roots only requires the postMatch hook,
+      // so this lifecycle callback of IPostProcessor is deliberately a no-op.
     }
 
     public MatchRoots(final EObject leftRoot, final EObject rightRoot) {


### PR DESCRIPTION
Fixes #432

`MatchRoots` (a private `IPostProcessor` used by `ModelDeepEqualityMatcher`) had five empty method bodies with no indication of whether the emptiness was intentional (SonarCloud `java:S1186`, HIGH):

- `postComparison` (line 108)
- `postConflicts` (line 112)
- `postDiff` (line 116)
- `postEquivalences` (line 120)
- `postRequirements` (line 161)

## Fix
Add a comment to each empty method explaining that the hook is intentionally a no-op because only `postMatch` is required. S1186 treats a commented empty method as documented/intentional.


