### PR TITLE
Document the intentionally-empty componentAdded hook in ChangeVisualizationUI

### DIFF
--- a/testutils/changevisualization/src/main/java/tools/vitruv/change/testutils/changevisualization/ChangeVisualizationUI.java
+++ b/testutils/changevisualization/src/main/java/tools/vitruv/change/testutils/changevisualization/ChangeVisualizationUI.java
@@ -139,7 +139,10 @@ public class ChangeVisualizationUI extends JFrame implements MonitoredRepository
     tabbedPane.addContainerListener(
         new ContainerListener() {
           @Override
-          public void componentAdded(ContainerEvent e) {}
+          public void componentAdded(ContainerEvent e) {
+            // Intentionally empty: only tab removal needs to be tracked here,
+            // so component additions require no action.
+          }
 
           @Override
           public void componentRemoved(ContainerEvent e) {


### PR DESCRIPTION
Fixes #443

The anonymous `ContainerListener` registered on the tabbed pane in `ChangeVisualizationUI` only needs to react to tab **removal** (`componentRemoved`). Its `componentAdded` implementation was an empty method with no indication of whether the emptiness was intentional (SonarCloud `java:S1186`, HIGH).

## Fix
Add a comment documenting that `componentAdded` is intentionally a no-op. Throwing would be wrong here: AWT fires this callback whenever a tab is added, so it must remain a callable no-op.

## Verification
- `testutils/changevisualization` compiles.
- The changed lines are checkstyle-clean.
