### PR TITLE
Access NO_INDEX through its declaring type Notification in NotificationInfo

### DIFF
--- a/composite/src/main/java/tools/vitruv/change/composite/recording/NotificationInfo.java
+++ b/composite/src/main/java/tools/vitruv/change/composite/recording/NotificationInfo.java
@@ -241,7 +241,7 @@ class NotificationInfo implements Notification {
   public int getInitialIndex() {
     int xifexpression = (int) 0;
     int position = this.getPosition();
-    boolean tripleEquals = (position == NotificationInfo.NO_INDEX);
+    boolean tripleEquals = (position == Notification.NO_INDEX);
     if (tripleEquals) {
       xifexpression = 0;
     } else {


### PR DESCRIPTION
Fixes #444

`NO_INDEX` is a `static` constant declared in `org.eclipse.emf.common.notify.Notification`. In `NotificationInfo.getInitialIndex()` it was accessed through the subtype `NotificationInfo` (`NotificationInfo.NO_INDEX`), which obscures where the constant actually comes from (SonarCloud `java:S3252`, HIGH).

## Fix
Access the constant through its declaring type: `Notification.NO_INDEX`. `Notification` is already imported and `NotificationInfo implements Notification`, so the value is unchanged.

## Verification
- `composite` compiles.
- The changed line is checkstyle-clean.
