### PR TITLE
Move HIGHLIGHT_COLOR out of the TabColours constant interface

### DIFF
--- a/testutils/changevisualization/src/main/java/tools/vitruv/change/testutils/changevisualization/tree/ChangeTreeNodeRenderer.java
+++ b/testutils/changevisualization/src/main/java/tools/vitruv/change/testutils/changevisualization/tree/ChangeTreeNodeRenderer.java
@@ -12,8 +12,7 @@ import javax.swing.JTree;
 import javax.swing.tree.DefaultMutableTreeNode;
 import javax.swing.tree.DefaultTreeCellRenderer;
 import javax.swing.tree.TreeNode;
-
-import tools.vitruv.change.testutils.changevisualization.ui.ChangesTab;
+import tools.vitruv.change.testutils.changevisualization.ui.TabColours;
 
 
 /**
@@ -166,7 +165,7 @@ public class ChangeTreeNodeRenderer extends DefaultTreeCellRenderer {
     // if the node is highlighted, set the color after super.getTreeCell...
     // to overwrite any potential coloring of the superclasses implementation
     if (shouldHighlight(value)) {
-      comp.setForeground(ChangesTab.HIGHLIGHT_COLOR);
+      comp.setForeground(TabColours.HIGHLIGHT_COLOR);
     }
 
     return comp;

--- a/testutils/changevisualization/src/main/java/tools/vitruv/change/testutils/changevisualization/ui/ChangesTab.java
+++ b/testutils/changevisualization/src/main/java/tools/vitruv/change/testutils/changevisualization/ui/ChangesTab.java
@@ -22,7 +22,7 @@ import tools.vitruv.change.testutils.changevisualization.tree.TabHighlighting;
  * to displaying general information.
  */
 public class ChangesTab extends JPanel
-    implements ListSelectionListener, ChangeDataSetGenerationListener, TabHighlighting, TabColours {
+    implements ListSelectionListener, ChangeDataSetGenerationListener, TabHighlighting {
   private static final long serialVersionUID = -5293272783862251463L;
 
   /** The ChangeComponent implementing the actual visualization. */

--- a/testutils/changevisualization/src/main/java/tools/vitruv/change/testutils/changevisualization/ui/TabColours.java
+++ b/testutils/changevisualization/src/main/java/tools/vitruv/change/testutils/changevisualization/ui/TabColours.java
@@ -2,7 +2,13 @@ package tools.vitruv.change.testutils.changevisualization.ui;
 
 import java.awt.Color;
 
-public interface TabColours {
-      /** The color used to highlight objects. */
+/** Holds the colours shared by the change-visualization tabs. */
+public final class TabColours {
+
+  /** The color used to highlight objects. */
   public static final Color HIGHLIGHT_COLOR = Color.BLUE;
+
+  private TabColours() {
+    // Utility class: not meant to be instantiated.
+  }
 }

--- a/testutils/changevisualization/src/test/java/tools/vitruv/change/testutils/changevisualization/tree/ChangeTreeNodeRendererTest.java
+++ b/testutils/changevisualization/src/test/java/tools/vitruv/change/testutils/changevisualization/tree/ChangeTreeNodeRendererTest.java
@@ -1,0 +1,61 @@
+package tools.vitruv.change.testutils.changevisualization.tree;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.awt.Component;
+import javax.swing.JTree;
+import javax.swing.SwingUtilities;
+import javax.swing.tree.DefaultMutableTreeNode;
+import org.junit.jupiter.api.Test;
+import tools.vitruv.change.testutils.changevisualization.ui.TabColours;
+
+class ChangeTreeNodeRendererTest {
+
+  private static TabHighlighting highlightingFor(String id) {
+    return new TabHighlighting() {
+      @Override
+      public void setHighlightID(String highlightID) {
+        // Not needed for this test.
+      }
+
+      @Override
+      public String getHighlightID() {
+        return id;
+      }
+    };
+  }
+
+  private static DefaultMutableTreeNode featureNode(String featureName) {
+    return new DefaultMutableTreeNode(new FeatureNode(featureName, "value", null, null, null));
+  }
+
+  @Test
+  void highlightedNodeIsRenderedWithHighlightColour() throws Exception {
+    SwingUtilities.invokeAndWait(
+        () -> {
+          ChangeTreeNodeRenderer renderer = new ChangeTreeNodeRenderer(highlightingFor("HL"));
+          renderer.setActive(true);
+
+          Component comp =
+              renderer.getTreeCellRendererComponent(
+                  new JTree(), featureNode("HL"), false, false, true, 0, false);
+
+          assertThat(comp.getForeground()).isEqualTo(TabColours.HIGHLIGHT_COLOR);
+        });
+  }
+
+  @Test
+  void nonMatchingNodeIsNotHighlighted() throws Exception {
+    SwingUtilities.invokeAndWait(
+        () -> {
+          ChangeTreeNodeRenderer renderer = new ChangeTreeNodeRenderer(highlightingFor("HL"));
+          renderer.setActive(true);
+
+          Component comp =
+              renderer.getTreeCellRendererComponent(
+                  new JTree(), featureNode("unrelated"), false, false, true, 0, false);
+
+          assertThat(comp.getForeground()).isNotEqualTo(TabColours.HIGHLIGHT_COLOR);
+        });
+  }
+}


### PR DESCRIPTION
Fixes #445

`TabColours` was an interface whose only member was the `HIGHLIGHT_COLOR` constant, and `ChangesTab implements TabColours` purely to inherit that constant. Declaring constants in an interface and inheriting them this way is the "constant interface" anti-pattern (SonarCloud `java:S1214`, HIGH).

## Fix
- Convert `TabColours` into a `final` utility class with a private constructor (avoiding the implicit public constructor).
- Drop the now-unnecessary `implements TabColours` from `ChangesTab` (it never used the constant directly).
- Reference the constant through the declaring type in `ChangeTreeNodeRenderer` (`TabColours.HIGHLIGHT_COLOR` instead of `ChangesTab.HIGHLIGHT_COLOR`). `ChangeDataSetTable` already used `TabColours.HIGHLIGHT_COLOR`.

The constant's value is unchanged. `TabColours` is not used as a type anywhere, so removing the `implements` has no behavioural effect.

## Verification
- `testutils/changevisualization` compiles.
- All changed lines are checkstyle-clean (new `TabColours` class included).
