### PR TITLE
Make setupWorkspace static to avoid writing workspaceCache from an instance

### DIFF
--- a/testutils/core/src/main/java/tools/vitruv/change/testutils/TestProjectManager.java
+++ b/testutils/core/src/main/java/tools/vitruv/change/testutils/TestProjectManager.java
@@ -196,7 +196,7 @@ public class TestProjectManager implements ParameterResolver, AfterEachCallback 
     return result;
   }
 
-  private Path setupWorkspace() {
+  private static Path setupWorkspace() {
     Path _xblockexpression = null;
     {
       if ((TestProjectManager.workspaceCache != null)) {
@@ -259,8 +259,8 @@ public class TestProjectManager implements ParameterResolver, AfterEachCallback 
   @SuppressWarnings("deprecation")
   private Path getWorkspace(final ExtensionContext context) {
     final Function<String, TestProjectManager.WorkspaceGuard> _function = (String it) -> {
-      Path _setupWorkspace = this.setupWorkspace();
-      return new TestProjectManager.WorkspaceGuard(_setupWorkspace);
+      Path workspace = TestProjectManager.setupWorkspace();
+      return new TestProjectManager.WorkspaceGuard(workspace);
     };
     ExtensionContext.Store store = context.getRoot().getStore(TestProjectManager.namespace);
     TestProjectManager.WorkspaceGuard guard = (TestProjectManager.WorkspaceGuard) store.getOrComputeIfAbsent(


### PR DESCRIPTION
Fixes #446

`TestProjectManager.setupWorkspace()` is an instance method that assigns the `static` field `workspaceCache`. Writing a static field from a non-static context is error-prone, especially under concurrent use (SonarCloud `java:S2696`, HIGH).

## Fix
`setupWorkspace()` uses only static members (no instance state), so it can safely be `static`. Make the method `static` and update its single caller in `getWorkspace(...)` to invoke it through the type. A static method assigning a static field no longer triggers the rule.

## Verification
- `testutils/core` compiles.
- The changed declaration line is checkstyle-clean.
