### PR TITLE
Remove wildcard return types from ModelMatchers

### DIFF
--- a/testutils/core/src/main/java/tools/vitruv/change/testutils/matchers/ModelMatchers.java
+++ b/testutils/core/src/main/java/tools/vitruv/change/testutils/matchers/ModelMatchers.java
@@ -12,7 +12,7 @@ import org.eclipse.emf.ecore.resource.Resource;
 import org.hamcrest.Matcher;
 
 public final class ModelMatchers {
-  public static Matcher<? super Resource> containsModelOf(final Resource expected,
+  public static Matcher<Resource> containsModelOf(final Resource expected,
       final ModelDeepEqualityOption... options) {
     return ModelMatchers.contains(ModelMatchers.checkResourceContent(expected), options);
   }
@@ -35,11 +35,11 @@ public final class ModelMatchers {
     return _xblockexpression;
   }
 
-  public static Matcher<? super Resource> contains(final EObject root, final ModelDeepEqualityOption... options) {
+  public static Matcher<Resource> contains(final EObject root, final ModelDeepEqualityOption... options) {
     return ModelMatchers.contains(ModelMatchers.<EObject>equalsDeeply(root, options));
   }
 
-  public static Matcher<? super Resource> contains(final Matcher<? super EObject> rootMatcher) {
+  public static Matcher<Resource> contains(final Matcher<? super EObject> rootMatcher) {
     return new ResourceContainmentMatcher(rootMatcher);
   }
 
@@ -52,9 +52,9 @@ public final class ModelMatchers {
    * @param searchedItems items, of which all should be contained.
    * @param options       ...
    */
-  public static Matcher<? super Iterable<? extends EObject>> containsAllOf(
+  public static <T extends Iterable<? extends EObject>> Matcher<T> containsAllOf(
       final Iterable<? extends EObject> searchedItems, final ModelDeepEqualityOption... options) {
-    return new EListMultipleContainmentMatcher(searchedItems, true, options);
+    return ModelMatchers.<T>asIterableMatcher(new EListMultipleContainmentMatcher(searchedItems, true, options));
   }
 
   /**
@@ -66,9 +66,9 @@ public final class ModelMatchers {
    * @param searchedItems items, of which none should be contained.
    * @param options       ...
    */
-  public static Matcher<? super Iterable<? extends EObject>> containsNoneOf(
+  public static <T extends Iterable<? extends EObject>> Matcher<T> containsNoneOf(
       final Iterable<? extends EObject> searchedItems, final ModelDeepEqualityOption... options) {
-    return new EListMultipleContainmentMatcher(searchedItems, false, options);
+    return ModelMatchers.<T>asIterableMatcher(new EListMultipleContainmentMatcher(searchedItems, false, options));
   }
 
   /**
@@ -79,28 +79,35 @@ public final class ModelMatchers {
    * @param searchedItem item, which should be contained.
    * @param options      ...
    */
-  public static Matcher<? extends Iterable<? extends EObject>> listContains(final EObject searchedItem,
+  public static <T extends Iterable<? extends EObject>> Matcher<T> listContains(final EObject searchedItem,
       final ModelDeepEqualityOption... options) {
-    return new EListSingleContainmentMatcher(searchedItem, true, options);
+    return ModelMatchers.<T>asIterableMatcher(new EListSingleContainmentMatcher(searchedItem, true, options));
   }
 
-  public static Matcher<? super URI> isResource() {
+  private static <T extends Iterable<? extends EObject>> Matcher<T> asIterableMatcher(
+      final Matcher<Iterable<? extends EObject>> matcher) {
+    @SuppressWarnings("unchecked")
+    final Matcher<T> typedMatcher = (Matcher<T>) matcher;
+    return typedMatcher;
+  }
+
+  public static Matcher<URI> isResource() {
     return new ResourceExistingMatcher(true);
   }
 
-  public static Matcher<? super URI> isNoResource() {
+  public static Matcher<URI> isNoResource() {
     return new ResourceExistingMatcher(false);
   }
 
-  public static Matcher<? super Resource> exists() {
+  public static Matcher<Resource> exists() {
     return new ResourceExistenceMatcher(true);
   }
 
-  public static Matcher<? super Resource> doesNotExist() {
+  public static Matcher<Resource> doesNotExist() {
     return new ResourceExistenceMatcher(false);
   }
 
-  public static Matcher<? super EObject> isContainedIn(final Resource resource) {
+  public static Matcher<EObject> isContainedIn(final Resource resource) {
     return new EObjectResourceMatcher(resource);
   }
 
@@ -108,7 +115,7 @@ public final class ModelMatchers {
    * A highly configurable matcher for comparing EObjects with detailed difference
    * printing.
    */
-  public static <O extends EObject> Matcher<? super O> equalsDeeply(final O object,
+  public static <O extends EObject> Matcher<O> equalsDeeply(final O object,
       final ModelDeepEqualityOption... options) {
     return new ModelDeepEqualityMatcher<O>(object, List.of(options));
   }
@@ -153,15 +160,15 @@ public final class ModelMatchers {
     return new EqualsBasedEqualityStrategy(_of);
   }
 
-  public static Matcher<? super EObject> whose(final EStructuralFeature feature, final Matcher<?> featureMatcher) {
+  public static Matcher<EObject> whose(final EStructuralFeature feature, final Matcher<?> featureMatcher) {
     return new EObjectFeatureMatcher(feature, featureMatcher);
   }
 
-  public static Matcher<? super Object> isInstanceOf(final EClassifier classifier) {
+  public static Matcher<Object> isInstanceOf(final EClassifier classifier) {
     return new InstanceOfEClassifierMatcher(classifier);
   }
 
-  public static Matcher<? super Resource> hasNoErrors() {
+  public static Matcher<Resource> hasNoErrors() {
     return new ResourceHasNoErrorsMatcher();
   }
 

--- a/testutils/core/src/main/java/tools/vitruv/change/testutils/matchers/ModelMatchers.java
+++ b/testutils/core/src/main/java/tools/vitruv/change/testutils/matchers/ModelMatchers.java
@@ -12,6 +12,9 @@ import org.eclipse.emf.ecore.resource.Resource;
 import org.hamcrest.Matcher;
 
 public final class ModelMatchers {
+  /**
+   * Matches resources that contain a model deeply equal to the expected resource.
+   */
   public static Matcher<Resource> containsModelOf(final Resource expected,
       final ModelDeepEqualityOption... options) {
     return ModelMatchers.contains(ModelMatchers.checkResourceContent(expected), options);
@@ -35,10 +38,17 @@ public final class ModelMatchers {
     return _xblockexpression;
   }
 
-  public static Matcher<Resource> contains(final EObject root, final ModelDeepEqualityOption... options) {
+  /**
+   * Matches resources that contain a root object deeply equal to {@code root}.
+   */
+  public static Matcher<Resource> contains(final EObject root,
+      final ModelDeepEqualityOption... options) {
     return ModelMatchers.contains(ModelMatchers.<EObject>equalsDeeply(root, options));
   }
 
+  /**
+   * Matches resources whose single root object satisfies the given matcher.
+   */
   public static Matcher<Resource> contains(final Matcher<? super EObject> rootMatcher) {
     return new ResourceContainmentMatcher(rootMatcher);
   }
@@ -54,7 +64,8 @@ public final class ModelMatchers {
    */
   public static <T extends Iterable<? extends EObject>> Matcher<T> containsAllOf(
       final Iterable<? extends EObject> searchedItems, final ModelDeepEqualityOption... options) {
-    return ModelMatchers.<T>asIterableMatcher(new EListMultipleContainmentMatcher(searchedItems, true, options));
+    return ModelMatchers.<T>asIterableMatcher(
+        new EListMultipleContainmentMatcher(searchedItems, true, options));
   }
 
   /**
@@ -68,7 +79,8 @@ public final class ModelMatchers {
    */
   public static <T extends Iterable<? extends EObject>> Matcher<T> containsNoneOf(
       final Iterable<? extends EObject> searchedItems, final ModelDeepEqualityOption... options) {
-    return ModelMatchers.<T>asIterableMatcher(new EListMultipleContainmentMatcher(searchedItems, false, options));
+    return ModelMatchers.<T>asIterableMatcher(
+        new EListMultipleContainmentMatcher(searchedItems, false, options));
   }
 
   /**
@@ -79,9 +91,10 @@ public final class ModelMatchers {
    * @param searchedItem item, which should be contained.
    * @param options      ...
    */
-  public static <T extends Iterable<? extends EObject>> Matcher<T> listContains(final EObject searchedItem,
-      final ModelDeepEqualityOption... options) {
-    return ModelMatchers.<T>asIterableMatcher(new EListSingleContainmentMatcher(searchedItem, true, options));
+  public static <T extends Iterable<? extends EObject>> Matcher<T> listContains(
+      final EObject searchedItem, final ModelDeepEqualityOption... options) {
+    return ModelMatchers.<T>asIterableMatcher(
+        new EListSingleContainmentMatcher(searchedItem, true, options));
   }
 
   private static <T extends Iterable<? extends EObject>> Matcher<T> asIterableMatcher(
@@ -91,22 +104,37 @@ public final class ModelMatchers {
     return typedMatcher;
   }
 
+  /**
+   * Matches URIs that point to existing resources.
+   */
   public static Matcher<URI> isResource() {
     return new ResourceExistingMatcher(true);
   }
 
+  /**
+   * Matches URIs that do not point to existing resources.
+   */
   public static Matcher<URI> isNoResource() {
     return new ResourceExistingMatcher(false);
   }
 
+  /**
+   * Matches resources whose URI exists.
+   */
   public static Matcher<Resource> exists() {
     return new ResourceExistenceMatcher(true);
   }
 
+  /**
+   * Matches resources whose URI does not exist.
+   */
   public static Matcher<Resource> doesNotExist() {
     return new ResourceExistenceMatcher(false);
   }
 
+  /**
+   * Matches objects contained in the given resource.
+   */
   public static Matcher<EObject> isContainedIn(final Resource resource) {
     return new EObjectResourceMatcher(resource);
   }
@@ -160,14 +188,24 @@ public final class ModelMatchers {
     return new EqualsBasedEqualityStrategy(_of);
   }
 
-  public static Matcher<EObject> whose(final EStructuralFeature feature, final Matcher<?> featureMatcher) {
+  /**
+   * Matches objects whose feature value satisfies the given matcher.
+   */
+  public static Matcher<EObject> whose(final EStructuralFeature feature,
+      final Matcher<?> featureMatcher) {
     return new EObjectFeatureMatcher(feature, featureMatcher);
   }
 
+  /**
+   * Matches values that are instances of the given Ecore classifier.
+   */
   public static Matcher<Object> isInstanceOf(final EClassifier classifier) {
     return new InstanceOfEClassifierMatcher(classifier);
   }
 
+  /**
+   * Matches resources without diagnostics.
+   */
   public static Matcher<Resource> hasNoErrors() {
     return new ResourceHasNoErrorsMatcher();
   }

--- a/testutils/core/src/test/java/tools/vitruv/change/testutils/matchers/ModelMatchersTest.java
+++ b/testutils/core/src/test/java/tools/vitruv/change/testutils/matchers/ModelMatchersTest.java
@@ -1,0 +1,123 @@
+package tools.vitruv.change.testutils.matchers;
+
+import allElementTypes.AllElementTypesPackage;
+import allElementTypes.NonRoot;
+import allElementTypes.Root;
+import edu.kit.ipd.sdq.commons.util.org.eclipse.emf.ecore.resource.ResourceSetUtil;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.emf.ecore.resource.ResourceSet;
+import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import tools.vitruv.change.testutils.metamodels.AllElementTypesCreators;
+
+public class ModelMatchersTest {
+  @Test
+  public void containsModelOfMatchesDeeplyEqualResource(final @TempDir Path testFolder)
+      throws IOException {
+    final Resource expected = this.resource(testFolder.resolve("expected.aet"));
+    expected.getContents().add(root("root"));
+
+    final Resource actual = this.resource(testFolder.resolve("actual.aet"));
+    actual.getContents().add(root("root"));
+    actual.save(Map.of());
+
+    MatcherAssert.assertThat(actual, ModelMatchers.containsModelOf(expected));
+  }
+
+  @Test
+  public void containsMatchesDeeplyEqualRoot(final @TempDir Path testFolder) throws IOException {
+    final Resource resource = this.resource(testFolder.resolve("model.aet"));
+    resource.getContents().add(root("root"));
+    resource.save(Map.of());
+
+    MatcherAssert.assertThat(resource, ModelMatchers.contains(root("root")));
+  }
+
+  @Test
+  public void containsAcceptsRootMatcher(final @TempDir Path testFolder) throws IOException {
+    final Resource resource = this.resource(testFolder.resolve("model.aet"));
+    final Root root = root("root");
+    resource.getContents().add(root);
+    resource.save(Map.of());
+
+    MatcherAssert.assertThat(resource, ModelMatchers.contains(CoreMatchers.sameInstance(root)));
+  }
+
+  @Test
+  public void iterableMatchersAcceptTypedLists() {
+    final NonRoot first = nonRoot("first");
+    final NonRoot second = nonRoot("second");
+    final List<NonRoot> contents = List.of(first);
+
+    MatcherAssert.assertThat(contents, ModelMatchers.containsAllOf(List.of(nonRoot("first"))));
+    MatcherAssert.assertThat(contents, ModelMatchers.containsNoneOf(List.of(second)));
+    MatcherAssert.assertThat(contents, ModelMatchers.listContains(nonRoot("first")));
+  }
+
+  @Test
+  public void resourceUriMatchersUseExistingFiles(final @TempDir Path testFolder)
+      throws IOException {
+    final Resource existingResource = this.resource(testFolder.resolve("existing.aet"));
+    existingResource.getContents().add(root("root"));
+    existingResource.save(Map.of());
+
+    final Resource missingResource = this.resource(testFolder.resolve("missing.aet"));
+
+    MatcherAssert.assertThat(existingResource.getURI(), ModelMatchers.isResource());
+    MatcherAssert.assertThat(missingResource.getURI(), ModelMatchers.isNoResource());
+    MatcherAssert.assertThat(existingResource, ModelMatchers.exists());
+    MatcherAssert.assertThat(missingResource, ModelMatchers.doesNotExist());
+  }
+
+  @Test
+  public void objectMatchersMatchModelProperties(final @TempDir Path testFolder)
+      throws IOException {
+    final Resource resource = this.resource(testFolder.resolve("model.aet"));
+    final Root root = root("root");
+    resource.getContents().add(root);
+    resource.save(Map.of());
+
+    MatcherAssert.assertThat(root, ModelMatchers.isContainedIn(resource));
+    MatcherAssert.assertThat(root, ModelMatchers.<Root>equalsDeeply(root("root")));
+    MatcherAssert.assertThat(
+        root,
+        ModelMatchers.whose(
+            AllElementTypesPackage.Literals.IDENTIFIED__ID,
+            CoreMatchers.is("root")));
+    MatcherAssert.assertThat(
+        root,
+        ModelMatchers.isInstanceOf(AllElementTypesPackage.Literals.ROOT));
+  }
+
+  @Test
+  public void hasNoErrorsMatchesResourceWithoutDiagnostics(final @TempDir Path testFolder) {
+    final Resource resource = this.resource(testFolder.resolve("model.aet"));
+
+    MatcherAssert.assertThat(resource, ModelMatchers.hasNoErrors());
+  }
+
+  private Resource resource(final Path path) {
+    final ResourceSet resourceSet = ResourceSetUtil.withGlobalFactories(new ResourceSetImpl());
+    return resourceSet.createResource(URI.createFileURI(path.toString()));
+  }
+
+  private static Root root(final String id) {
+    final Root root = AllElementTypesCreators.aet.Root();
+    root.setId(id);
+    return root;
+  }
+
+  private static NonRoot nonRoot(final String id) {
+    final NonRoot nonRoot = AllElementTypesCreators.aet.NonRoot();
+    nonRoot.setId(id);
+    return nonRoot;
+  }
+}

--- a/testutils/core/src/test/java/tools/vitruv/change/testutils/matchers/ModelMatchersTest.java
+++ b/testutils/core/src/test/java/tools/vitruv/change/testutils/matchers/ModelMatchersTest.java
@@ -18,9 +18,12 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import tools.vitruv.change.testutils.metamodels.AllElementTypesCreators;
 
-public class ModelMatchersTest {
+/**
+ * Tests the factory methods exposed by {@link ModelMatchers}.
+ */
+class ModelMatchersTest {
   @Test
-  public void containsModelOfMatchesDeeplyEqualResource(final @TempDir Path testFolder)
+  void containsModelOfMatchesDeeplyEqualResource(final @TempDir Path testFolder)
       throws IOException {
     final Resource expected = this.resource(testFolder.resolve("expected.aet"));
     expected.getContents().add(root("root"));
@@ -33,7 +36,7 @@ public class ModelMatchersTest {
   }
 
   @Test
-  public void containsMatchesDeeplyEqualRoot(final @TempDir Path testFolder) throws IOException {
+  void containsMatchesDeeplyEqualRoot(final @TempDir Path testFolder) throws IOException {
     final Resource resource = this.resource(testFolder.resolve("model.aet"));
     resource.getContents().add(root("root"));
     resource.save(Map.of());
@@ -42,7 +45,7 @@ public class ModelMatchersTest {
   }
 
   @Test
-  public void containsAcceptsRootMatcher(final @TempDir Path testFolder) throws IOException {
+  void containsAcceptsRootMatcher(final @TempDir Path testFolder) throws IOException {
     final Resource resource = this.resource(testFolder.resolve("model.aet"));
     final Root root = root("root");
     resource.getContents().add(root);
@@ -52,7 +55,7 @@ public class ModelMatchersTest {
   }
 
   @Test
-  public void iterableMatchersAcceptTypedLists() {
+  void iterableMatchersAcceptTypedLists() {
     final NonRoot first = nonRoot("first");
     final NonRoot second = nonRoot("second");
     final List<NonRoot> contents = List.of(first);
@@ -63,7 +66,7 @@ public class ModelMatchersTest {
   }
 
   @Test
-  public void resourceUriMatchersUseExistingFiles(final @TempDir Path testFolder)
+  void resourceUriMatchersUseExistingFiles(final @TempDir Path testFolder)
       throws IOException {
     final Resource existingResource = this.resource(testFolder.resolve("existing.aet"));
     existingResource.getContents().add(root("root"));
@@ -78,7 +81,7 @@ public class ModelMatchersTest {
   }
 
   @Test
-  public void objectMatchersMatchModelProperties(final @TempDir Path testFolder)
+  void objectMatchersMatchModelProperties(final @TempDir Path testFolder)
       throws IOException {
     final Resource resource = this.resource(testFolder.resolve("model.aet"));
     final Root root = root("root");
@@ -98,7 +101,7 @@ public class ModelMatchersTest {
   }
 
   @Test
-  public void hasNoErrorsMatchesResourceWithoutDiagnostics(final @TempDir Path testFolder) {
+  void hasNoErrorsMatchesResourceWithoutDiagnostics(final @TempDir Path testFolder) {
     final Resource resource = this.resource(testFolder.resolve("model.aet"));
 
     MatcherAssert.assertThat(resource, ModelMatchers.hasNoErrors());


### PR DESCRIPTION
## Summary

Refactors `ModelMatchers` matcher factory methods to avoid wildcard generic return types.

The public return types now use concrete `Matcher<T>` forms such as `Matcher<Resource>`, `Matcher<URI>`, `Matcher<EObject>`, and generic `Matcher<T>` for iterable matchers. This resolves the SonarQube `java:S1452` maintainability issue while keeping the change scoped to `ModelMatchers`.