### PR TITLE
Extract event type constant

### DIFF
--- a/composite/src/main/java/tools/vitruv/change/composite/message/Error.java
+++ b/composite/src/main/java/tools/vitruv/change/composite/message/Error.java
@@ -1,0 +1,13 @@
+package tools.vitruv.change.composite.message;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+/**
+ * Holds constant error messages.
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class Error {
+  public static final String UNEXPECTED_EVENT_TYPE = "Unexpected event type ";
+  public static final String RESOURCE_URI_NOTIFICATION = " for Resource URI Notification.";
+}

--- a/composite/src/main/java/tools/vitruv/change/composite/recording/NotificationToEChangeConverter.java
+++ b/composite/src/main/java/tools/vitruv/change/composite/recording/NotificationToEChangeConverter.java
@@ -52,10 +52,6 @@ final class NotificationToEChangeConverter {
     );
   }
 
-  private static String unexpectedEventTypeMessage(final NotificationInfo notification) {
-    return UNEXPECTED_EVENT_TYPE + Integer.valueOf(notification.getEventType());
-  }
-
   private final String ATTRIBUTE_TYPE = "Attribute";
 
   private final String REFERENCE_TYPE = "Reference";
@@ -187,14 +183,14 @@ final class NotificationToEChangeConverter {
   }
 
   private IllegalArgumentException unexpectedEventType(final NotificationInfo notification) {
-    return new IllegalArgumentException("Unexpected event type " + notification.getEventType());
+    return new IllegalArgumentException(UNEXPECTED_EVENT_TYPE + notification.getEventType());
   }
 
   private IllegalArgumentException unexpectedResourceUriEventType(
           final NotificationInfo notification) {
-    final String message = "Unexpected event type "
+    final String message = UNEXPECTED_EVENT_TYPE
             + notification.getEventType()
-            + " for Resource URI Notification.";
+            + RESOURCE_URI_NOTIFICATION;
 
     return new IllegalArgumentException(message);
   }

--- a/composite/src/main/java/tools/vitruv/change/composite/recording/NotificationToEChangeConverter.java
+++ b/composite/src/main/java/tools/vitruv/change/composite/recording/NotificationToEChangeConverter.java
@@ -102,9 +102,7 @@ final class NotificationToEChangeConverter {
       case REMOVE -> this.handleRemoveAttribute(notification);
       case REMOVE_MANY -> this.handleMultiRemoveAttribute(notification);
       case MOVE -> this.handleMoveAttribute(notification);
-      case RESOLVE, REMOVING_ADAPTER -> {
-        throw unexpectedNotificationEvent(eventType, ATTRIBUTE_TYPE);
-      }
+      case RESOLVE, REMOVING_ADAPTER -> throw unexpectedNotificationEvent(eventType, ATTRIBUTE_TYPE);
       default -> throw unexpectedEventType(notification);
     };
   }
@@ -121,9 +119,7 @@ final class NotificationToEChangeConverter {
       case REMOVE -> this.handleRemoveReference(notification);
       case REMOVE_MANY -> this.handleMultiRemoveReference(notification);
       case MOVE -> this.handleMoveReference(notification);
-      case RESOLVE, REMOVING_ADAPTER -> {
-        throw unexpectedNotificationEvent(eventType, REFERENCE_TYPE);
-      }
+      case RESOLVE, REMOVING_ADAPTER -> throw unexpectedNotificationEvent(eventType, REFERENCE_TYPE);
       default -> throw unexpectedEventType(notification);
     };
   }

--- a/composite/src/main/java/tools/vitruv/change/composite/recording/NotificationToEChangeConverter.java
+++ b/composite/src/main/java/tools/vitruv/change/composite/recording/NotificationToEChangeConverter.java
@@ -1,17 +1,20 @@
 package tools.vitruv.change.composite.recording;
 
+import static tools.vitruv.change.composite.message.Error.RESOURCE_URI_NOTIFICATION;
+import static tools.vitruv.change.composite.message.Error.UNEXPECTED_EVENT_TYPE;
+
 import com.google.common.collect.Iterables;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.function.BiFunction;
+import java.util.function.Function;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EAttribute;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EReference;
 import org.eclipse.emf.ecore.EStructuralFeature;
 import org.eclipse.emf.ecore.resource.Resource;
-import java.util.function.Function;
-import java.util.function.BiFunction;
 import tools.vitruv.change.atomic.EChange;
 import tools.vitruv.change.atomic.TypeInferringAtomicEChangeFactory;
 import tools.vitruv.change.atomic.eobject.CreateEObject;
@@ -33,9 +36,6 @@ import tools.vitruv.change.atomic.root.RemoveRootEObject;
  * @author Heiko Klare
  */
 final class NotificationToEChangeConverter {
-  private static final String UNEXPECTED_EVENT_TYPE_MESSAGE = "Unexpected event type ";
-  private static final String RESOURCE_URI_NOTIFICATION_MESSAGE = " for Resource URI Notification.";
-
   private final TypeInferringAtomicEChangeFactory changeFactory = TypeInferringAtomicEChangeFactory.getInstance();
 
   private final BiFunction<EObject, EObject, Boolean> isCreateChange;
@@ -49,7 +49,7 @@ final class NotificationToEChangeConverter {
   }
 
   private static String unexpectedEventTypeMessage(final NotificationInfo notification) {
-    return UNEXPECTED_EVENT_TYPE_MESSAGE + Integer.valueOf(notification.getEventType());
+    return UNEXPECTED_EVENT_TYPE + Integer.valueOf(notification.getEventType());
   }
 
   private final String ATTRIBUTE_TYPE = "Attribute";
@@ -240,11 +240,11 @@ final class NotificationToEChangeConverter {
                   break;
                 default:
                   throw new IllegalArgumentException(
-                      unexpectedEventTypeMessage(notification) + RESOURCE_URI_NOTIFICATION_MESSAGE);
+                      unexpectedEventTypeMessage(notification) + RESOURCE_URI_NOTIFICATION);
               }
             } else {
               throw new IllegalArgumentException(
-                  unexpectedEventTypeMessage(notification) + RESOURCE_URI_NOTIFICATION_MESSAGE);
+                  unexpectedEventTypeMessage(notification) + RESOURCE_URI_NOTIFICATION);
             }
             _switchResult_3 = _switchResult_5;
             break;

--- a/composite/src/main/java/tools/vitruv/change/composite/recording/NotificationToEChangeConverter.java
+++ b/composite/src/main/java/tools/vitruv/change/composite/recording/NotificationToEChangeConverter.java
@@ -33,6 +33,8 @@ import tools.vitruv.change.atomic.root.RemoveRootEObject;
  * @author Heiko Klare
  */
 final class NotificationToEChangeConverter {
+  private static final String UNEXPECTED_EVENT_TYPE_MESSAGE = "Unexpected event type ";
+
   private final TypeInferringAtomicEChangeFactory changeFactory = TypeInferringAtomicEChangeFactory.getInstance();
 
   private final BiFunction<EObject, EObject, Boolean> isCreateChange;
@@ -119,12 +121,12 @@ final class NotificationToEChangeConverter {
               throw new IllegalArgumentException(_convertExceptionMessage_1);
             default:
               int _eventType = notification.getEventType();
-              String _plus = ("Unexpected event type " + Integer.valueOf(_eventType));
+              String _plus = (UNEXPECTED_EVENT_TYPE_MESSAGE + Integer.valueOf(_eventType));
               throw new IllegalArgumentException(_plus);
           }
         } else {
           int _eventType = notification.getEventType();
-          String _plus = ("Unexpected event type " + Integer.valueOf(_eventType));
+          String _plus = (UNEXPECTED_EVENT_TYPE_MESSAGE + Integer.valueOf(_eventType));
           throw new IllegalArgumentException(_plus);
         }
         _switchResult = _switchResult_1;
@@ -168,12 +170,12 @@ final class NotificationToEChangeConverter {
               throw new IllegalArgumentException(_convertExceptionMessage_3);
             default:
               int _eventType_1 = notification.getEventType();
-              String _plus_1 = ("Unexpected event type " + Integer.valueOf(_eventType_1));
+              String _plus_1 = (UNEXPECTED_EVENT_TYPE_MESSAGE + Integer.valueOf(_eventType_1));
               throw new IllegalArgumentException(_plus_1);
           }
         } else {
           int _eventType_1 = notification.getEventType();
-          String _plus_1 = ("Unexpected event type " + Integer.valueOf(_eventType_1));
+          String _plus_1 = (UNEXPECTED_EVENT_TYPE_MESSAGE + Integer.valueOf(_eventType_1));
           throw new IllegalArgumentException(_plus_1);
         }
         _switchResult = _switchResult_2;
@@ -225,12 +227,12 @@ final class NotificationToEChangeConverter {
                   throw new IllegalArgumentException(_convertExceptionMessage_8);
                 default:
                   int _eventType_2 = notification.getEventType();
-                  String _plus_2 = ("Unexpected event type " + Integer.valueOf(_eventType_2));
+                  String _plus_2 = (UNEXPECTED_EVENT_TYPE_MESSAGE + Integer.valueOf(_eventType_2));
                   throw new IllegalArgumentException(_plus_2);
               }
             } else {
               int _eventType_2 = notification.getEventType();
-              String _plus_2 = ("Unexpected event type " + Integer.valueOf(_eventType_2));
+              String _plus_2 = (UNEXPECTED_EVENT_TYPE_MESSAGE + Integer.valueOf(_eventType_2));
               throw new IllegalArgumentException(_plus_2);
             }
             _switchResult_3 = _switchResult_4;
@@ -245,13 +247,13 @@ final class NotificationToEChangeConverter {
                   break;
                 default:
                   int _eventType_3 = notification.getEventType();
-                  String _plus_3 = ("Unexpected event type " + Integer.valueOf(_eventType_3));
+                  String _plus_3 = (UNEXPECTED_EVENT_TYPE_MESSAGE + Integer.valueOf(_eventType_3));
                   String _plus_4 = (_plus_3 + " for Resource URI Notification.");
                   throw new IllegalArgumentException(_plus_4);
               }
             } else {
               int _eventType_3 = notification.getEventType();
-              String _plus_3 = ("Unexpected event type " + Integer.valueOf(_eventType_3));
+              String _plus_3 = (UNEXPECTED_EVENT_TYPE_MESSAGE + Integer.valueOf(_eventType_3));
               String _plus_4 = (_plus_3 + " for Resource URI Notification.");
               throw new IllegalArgumentException(_plus_4);
             }

--- a/composite/src/main/java/tools/vitruv/change/composite/recording/NotificationToEChangeConverter.java
+++ b/composite/src/main/java/tools/vitruv/change/composite/recording/NotificationToEChangeConverter.java
@@ -34,6 +34,7 @@ import tools.vitruv.change.atomic.root.RemoveRootEObject;
  */
 final class NotificationToEChangeConverter {
   private static final String UNEXPECTED_EVENT_TYPE_MESSAGE = "Unexpected event type ";
+  private static final String RESOURCE_URI_NOTIFICATION_MESSAGE = " for Resource URI Notification.";
 
   private final TypeInferringAtomicEChangeFactory changeFactory = TypeInferringAtomicEChangeFactory.getInstance();
 
@@ -45,6 +46,10 @@ final class NotificationToEChangeConverter {
 
   private String convertExceptionMessage(final EventType eventType, final String notificationType) {
     return String.format("Event type {} for {} Notifications unexpected.");
+  }
+
+  private static String unexpectedEventTypeMessage(final NotificationInfo notification) {
+    return UNEXPECTED_EVENT_TYPE_MESSAGE + Integer.valueOf(notification.getEventType());
   }
 
   private final String ATTRIBUTE_TYPE = "Attribute";
@@ -120,14 +125,10 @@ final class NotificationToEChangeConverter {
                   this.ATTRIBUTE_TYPE);
               throw new IllegalArgumentException(_convertExceptionMessage_1);
             default:
-              int _eventType = notification.getEventType();
-              String _plus = (UNEXPECTED_EVENT_TYPE_MESSAGE + Integer.valueOf(_eventType));
-              throw new IllegalArgumentException(_plus);
+              throw new IllegalArgumentException(unexpectedEventTypeMessage(notification));
           }
         } else {
-          int _eventType = notification.getEventType();
-          String _plus = (UNEXPECTED_EVENT_TYPE_MESSAGE + Integer.valueOf(_eventType));
-          throw new IllegalArgumentException(_plus);
+          throw new IllegalArgumentException(unexpectedEventTypeMessage(notification));
         }
         _switchResult = _switchResult_1;
       }
@@ -169,14 +170,10 @@ final class NotificationToEChangeConverter {
                   this.REFERENCE_TYPE);
               throw new IllegalArgumentException(_convertExceptionMessage_3);
             default:
-              int _eventType_1 = notification.getEventType();
-              String _plus_1 = (UNEXPECTED_EVENT_TYPE_MESSAGE + Integer.valueOf(_eventType_1));
-              throw new IllegalArgumentException(_plus_1);
+              throw new IllegalArgumentException(unexpectedEventTypeMessage(notification));
           }
         } else {
-          int _eventType_1 = notification.getEventType();
-          String _plus_1 = (UNEXPECTED_EVENT_TYPE_MESSAGE + Integer.valueOf(_eventType_1));
-          throw new IllegalArgumentException(_plus_1);
+          throw new IllegalArgumentException(unexpectedEventTypeMessage(notification));
         }
         _switchResult = _switchResult_2;
       }
@@ -226,14 +223,10 @@ final class NotificationToEChangeConverter {
                       this.RESOURCE_CONTENTS_TYPE);
                   throw new IllegalArgumentException(_convertExceptionMessage_8);
                 default:
-                  int _eventType_2 = notification.getEventType();
-                  String _plus_2 = (UNEXPECTED_EVENT_TYPE_MESSAGE + Integer.valueOf(_eventType_2));
-                  throw new IllegalArgumentException(_plus_2);
+                  throw new IllegalArgumentException(unexpectedEventTypeMessage(notification));
               }
             } else {
-              int _eventType_2 = notification.getEventType();
-              String _plus_2 = (UNEXPECTED_EVENT_TYPE_MESSAGE + Integer.valueOf(_eventType_2));
-              throw new IllegalArgumentException(_plus_2);
+              throw new IllegalArgumentException(unexpectedEventTypeMessage(notification));
             }
             _switchResult_3 = _switchResult_4;
             break;
@@ -246,16 +239,12 @@ final class NotificationToEChangeConverter {
                   _switchResult_5 = this.handleSetUriChange(notification);
                   break;
                 default:
-                  int _eventType_3 = notification.getEventType();
-                  String _plus_3 = (UNEXPECTED_EVENT_TYPE_MESSAGE + Integer.valueOf(_eventType_3));
-                  String _plus_4 = (_plus_3 + " for Resource URI Notification.");
-                  throw new IllegalArgumentException(_plus_4);
+                  throw new IllegalArgumentException(
+                      unexpectedEventTypeMessage(notification) + RESOURCE_URI_NOTIFICATION_MESSAGE);
               }
             } else {
-              int _eventType_3 = notification.getEventType();
-              String _plus_3 = (UNEXPECTED_EVENT_TYPE_MESSAGE + Integer.valueOf(_eventType_3));
-              String _plus_4 = (_plus_3 + " for Resource URI Notification.");
-              throw new IllegalArgumentException(_plus_4);
+              throw new IllegalArgumentException(
+                  unexpectedEventTypeMessage(notification) + RESOURCE_URI_NOTIFICATION_MESSAGE);
             }
             _switchResult_3 = _switchResult_5;
             break;

--- a/composite/src/main/java/tools/vitruv/change/composite/recording/NotificationToEChangeConverter.java
+++ b/composite/src/main/java/tools/vitruv/change/composite/recording/NotificationToEChangeConverter.java
@@ -102,7 +102,8 @@ final class NotificationToEChangeConverter {
       case REMOVE -> this.handleRemoveAttribute(notification);
       case REMOVE_MANY -> this.handleMultiRemoveAttribute(notification);
       case MOVE -> this.handleMoveAttribute(notification);
-      case RESOLVE, REMOVING_ADAPTER -> throw unexpectedNotificationEvent(eventType, ATTRIBUTE_TYPE);
+      case RESOLVE, REMOVING_ADAPTER ->
+          throw unexpectedNotificationEvent(eventType, ATTRIBUTE_TYPE);
       default -> throw unexpectedEventType(notification);
     };
   }
@@ -119,7 +120,8 @@ final class NotificationToEChangeConverter {
       case REMOVE -> this.handleRemoveReference(notification);
       case REMOVE_MANY -> this.handleMultiRemoveReference(notification);
       case MOVE -> this.handleMoveReference(notification);
-      case RESOLVE, REMOVING_ADAPTER -> throw unexpectedNotificationEvent(eventType, REFERENCE_TYPE);
+      case RESOLVE, REMOVING_ADAPTER ->
+          throw unexpectedNotificationEvent(eventType, REFERENCE_TYPE);
       default -> throw unexpectedEventType(notification);
     };
   }

--- a/composite/src/test/java/tools/vitruv/change/composite/recording/NotificationToEChangeConverterTest.java
+++ b/composite/src/test/java/tools/vitruv/change/composite/recording/NotificationToEChangeConverterTest.java
@@ -1,0 +1,124 @@
+package tools.vitruv.change.composite.recording;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.List;
+import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.emf.ecore.resource.impl.ResourceImpl;
+import org.junit.jupiter.api.Test;
+
+class NotificationToEChangeConverterTest {
+  private static final int UNEXPECTED_EVENT_TYPE = 999;
+
+  @Test
+  void unexpectedEventTypeMessageIsUsedForGeneralNotifications() {
+    final NotificationToEChangeConverter converter =
+        new NotificationToEChangeConverter((left, right) -> false);
+
+    for (final UnexpectedNotificationKind kind
+        : List.of(
+            UnexpectedNotificationKind.ATTRIBUTE,
+            UnexpectedNotificationKind.REFERENCE,
+            UnexpectedNotificationKind.RESOURCE_CONTENTS)) {
+      final IllegalArgumentException exception =
+          assertThrows(
+              IllegalArgumentException.class,
+              () -> converter.convert(new UnexpectedEventNotification(kind)));
+
+      assertEquals("Unexpected event type 999", exception.getMessage());
+    }
+  }
+
+  @Test
+  void unexpectedEventTypeMessageIncludesResourceUriContext() {
+    final NotificationToEChangeConverter converter =
+        new NotificationToEChangeConverter((left, right) -> false);
+
+    final IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> converter.convert(
+                new UnexpectedEventNotification(UnexpectedNotificationKind.RESOURCE_URI)));
+
+    assertEquals(
+        "Unexpected event type 999 for Resource URI Notification.",
+        exception.getMessage());
+  }
+
+  private enum UnexpectedNotificationKind {
+    ATTRIBUTE,
+    REFERENCE,
+    RESOURCE_CONTENTS,
+    RESOURCE_URI
+  }
+
+  private static class UnexpectedEventNotification extends NotificationInfo {
+    private final UnexpectedNotificationKind kind;
+
+    UnexpectedEventNotification(final UnexpectedNotificationKind kind) {
+      super(null);
+      this.kind = kind;
+    }
+
+    @Override
+    public EventType getEventTypeEnum() {
+      return null;
+    }
+
+    @Override
+    public int getEventType() {
+      return UNEXPECTED_EVENT_TYPE;
+    }
+
+    @Override
+    public Object getOldValue() {
+      return "old";
+    }
+
+    @Override
+    public Object getNewValue() {
+      return "new";
+    }
+
+    @Override
+    public boolean isTouch() {
+      return false;
+    }
+
+    @Override
+    public boolean isTransient() {
+      return false;
+    }
+
+    @Override
+    public boolean isAttributeNotification() {
+      return this.kind == UnexpectedNotificationKind.ATTRIBUTE;
+    }
+
+    @Override
+    public boolean isReferenceNotification() {
+      return this.kind == UnexpectedNotificationKind.REFERENCE;
+    }
+
+    @Override
+    public Object getNotifier() {
+      if (this.kind == UnexpectedNotificationKind.RESOURCE_CONTENTS
+          || this.kind == UnexpectedNotificationKind.RESOURCE_URI) {
+        return new ResourceImpl();
+      }
+      return null;
+    }
+
+    @Override
+    public int getFeatureID(final Class<?> expectedClass) {
+      if (this.kind == UnexpectedNotificationKind.RESOURCE_CONTENTS) {
+        return Resource.RESOURCE__CONTENTS;
+      }
+      if (this.kind == UnexpectedNotificationKind.RESOURCE_URI) {
+        return Resource.RESOURCE__URI;
+      }
+      return -1;
+    }
+  }
+}

--- a/composite/src/test/java/tools/vitruv/change/composite/recording/NotificationToEChangeConverterTest.java
+++ b/composite/src/test/java/tools/vitruv/change/composite/recording/NotificationToEChangeConverterTest.java
@@ -21,10 +21,11 @@ class NotificationToEChangeConverterTest {
             UnexpectedNotificationKind.ATTRIBUTE,
             UnexpectedNotificationKind.REFERENCE,
             UnexpectedNotificationKind.RESOURCE_CONTENTS)) {
+      final UnexpectedEventNotification notification = new UnexpectedEventNotification(kind);
       final IllegalArgumentException exception =
           assertThrows(
               IllegalArgumentException.class,
-              () -> converter.convert(new UnexpectedEventNotification(kind)));
+              () -> converter.convert(notification));
 
       assertEquals("Unexpected event type 999", exception.getMessage());
     }
@@ -34,12 +35,13 @@ class NotificationToEChangeConverterTest {
   void unexpectedEventTypeMessageIncludesResourceUriContext() {
     final NotificationToEChangeConverter converter =
         new NotificationToEChangeConverter((left, right) -> false);
+    final UnexpectedEventNotification notification =
+        new UnexpectedEventNotification(UnexpectedNotificationKind.RESOURCE_URI);
 
     final IllegalArgumentException exception =
         assertThrows(
             IllegalArgumentException.class,
-            () -> converter.convert(
-                new UnexpectedEventNotification(UnexpectedNotificationKind.RESOURCE_URI)));
+            () -> converter.convert(notification));
 
     assertEquals(
         "Unexpected event type 999 for Resource URI Notification.",


### PR DESCRIPTION
## Summary

This PR fixes the duplicated `"Unexpected event type "` literal in `NotificationToEChangeConverter.java` by moving the repeated message text into message constants.

A new `tools.vitruv.change.composite.message.Error` class was added for composite-specific error messages. This keeps the new constants separate from the existing `tools.vitruv.change.atomic.message.Error` class, which is used for atomic-specific messages.

## Changes

- Added composite-specific error message constants.
- Replaced duplicated unexpected event type message literals in `NotificationToEChangeConverter`.
- Kept atomic and composite error messages separated by module.