### PR TITLE
Differentiate unchanged ID test

### DIFF
--- a/atomic/src/test/java/tools/vitruv/change/atomic/hid/impl/HierarchicalIdResolverTest.java
+++ b/atomic/src/test/java/tools/vitruv/change/atomic/hid/impl/HierarchicalIdResolverTest.java
@@ -161,8 +161,14 @@ public class HierarchicalIdResolverTest {
       _contents.add(root);
     };
     _function.accept(_createResource);
-    Assertions.assertEquals(root, this.idResolver.getEObject(initialRootId));
-    Assertions.assertEquals(nonRoot, this.idResolver.getEObject(initialNonRootId));
+    final HierarchicalId updatedRootId = this.idResolver.getAndUpdateId(root);
+    final HierarchicalId updatedNonRootId = this.idResolver.getAndUpdateId(nonRoot);
+    Assertions.assertNotEquals(initialRootId, updatedRootId);
+    Assertions.assertNotEquals(initialNonRootId, updatedNonRootId);
+    Assertions.assertEquals(updatedRootId, this.idResolver.getAndUpdateId(root));
+    Assertions.assertEquals(updatedNonRootId, this.idResolver.getAndUpdateId(nonRoot));
+    Assertions.assertEquals(root, this.idResolver.getEObject(updatedRootId));
+    Assertions.assertEquals(nonRoot, this.idResolver.getEObject(updatedNonRootId));
   }
 
   @Test


### PR DESCRIPTION
## Summary
- Updated the unchanged-object ID test so it no longer duplicates the old-ID resolution test.
- Added assertions for