### PR TITLE
Fix All ChangeTree Sonar maintainability issues

### DIFF
--- a/testutils/changevisualization/src/main/java/tools/vitruv/change/testutils/changevisualization/tree/ChangeTree.java
+++ b/testutils/changevisualization/src/main/java/tools/vitruv/change/testutils/changevisualization/tree/ChangeTree.java
@@ -113,30 +113,44 @@ public class ChangeTree extends ChangeComponent {
    * @param path The path pointing to the selected node
    */
   private void updateDetailsUI(TreePath path) {
-    if (path != null) {
-      DefaultMutableTreeNode selectedNode = (DefaultMutableTreeNode) path.getLastPathComponent();
-      if (selectedNode != null) {
-        Object userObj = selectedNode.getUserObject();
-        if (userObj != null) {
-          if (userObj instanceof FeatureNode) {
-            String details = ((FeatureNode) userObj).getDetails();
-            String[][] detailsArray = ((FeatureNode) userObj).getDetailsArray();
-            Component detailsComp = ((FeatureNode) userObj).getDetailsUI();
-            if (details != null) {
-              detailsUI.setText(details);
-            } else if (detailsArray != null) {
-              detailsSplitpane.setRightComponent(new LabelValuePanel(detailsArray));
-            } else if (detailsComp != null) {
-              detailsSplitpane.setRightComponent(detailsComp);
-            }
-          } else if (userObj instanceof ChangeNode) {
-            // ChangeNode creates the component on the fly for us
-            Component detailsComp = ((ChangeNode) userObj).getDetailsUI();
-            detailsSplitpane.setRightComponent(detailsComp);
-          }
-        }
-      }
+    if (path == null) {
+      return;
     }
+
+    DefaultMutableTreeNode selectedNode = (DefaultMutableTreeNode) path.getLastPathComponent();
+    if (selectedNode == null) {
+      return;
+    }
+
+    updateDetailsForUserObject(selectedNode.getUserObject());
+  }
+
+  private void updateDetailsForUserObject(Object userObj) {
+    if (userObj instanceof FeatureNode) {
+      updateDetailsForFeatureNode((FeatureNode) userObj);
+    } else if (userObj instanceof ChangeNode) {
+      updateDetailsForChangeNode((ChangeNode) userObj);
+    }
+  }
+
+  private void updateDetailsForFeatureNode(FeatureNode featureNode) {
+    String details = featureNode.getDetails();
+    String[][] detailsArray = featureNode.getDetailsArray();
+    Component detailsComp = featureNode.getDetailsUI();
+
+    if (details != null) {
+      detailsUI.setText(details);
+    } else if (detailsArray != null) {
+      detailsSplitpane.setRightComponent(new LabelValuePanel(detailsArray));
+    } else if (detailsComp != null) {
+      detailsSplitpane.setRightComponent(detailsComp);
+    }
+  }
+
+  private void updateDetailsForChangeNode(ChangeNode changeNode) {
+    // ChangeNode creates the component on the fly for us
+    Component detailsComp = changeNode.getDetailsUI();
+    detailsSplitpane.setRightComponent(detailsComp);
   }
 
   /** The actual changeDataSet. */

--- a/testutils/changevisualization/src/main/java/tools/vitruv/change/testutils/changevisualization/tree/ChangeTree.java
+++ b/testutils/changevisualization/src/main/java/tools/vitruv/change/testutils/changevisualization/tree/ChangeTree.java
@@ -3,9 +3,9 @@ package tools.vitruv.change.testutils.changevisualization.tree;
 import java.awt.BorderLayout;
 import java.awt.Component;
 import java.awt.FlowLayout;
-import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.InputEvent;
+import java.util.Collections;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.Vector;
@@ -20,7 +20,6 @@ import javax.swing.JSplitPane;
 import javax.swing.JTextArea;
 import javax.swing.JTree;
 import javax.swing.border.TitledBorder;
-import javax.swing.event.TreeSelectionEvent;
 import javax.swing.event.TreeSelectionListener;
 import javax.swing.tree.DefaultMutableTreeNode;
 import javax.swing.tree.DefaultTreeModel;
@@ -91,58 +90,54 @@ public class ChangeTree extends ChangeComponent {
 
   /** The listener processing tree selection events of the JTree component. */
   private final transient TreeSelectionListener tsl =
-      new TreeSelectionListener() {
-        @Override
-        public void valueChanged(TreeSelectionEvent e) {
-          // reset details display to default behavior
-          detailsUI.setText("");
-          int divLocation = detailsSplitpane.getDividerLocation();
-          detailsSplitpane.setRightComponent(detailsScroller);
+      e -> {
+        // reset details display to default behavior
+        detailsUI.setText("");
+        int divLocation = detailsSplitpane.getDividerLocation();
+        detailsSplitpane.setRightComponent(detailsScroller);
 
-          // We have single selection mode ==> only one selected path
-          TreePath path = e.getNewLeadSelectionPath();
+        // We have single selection mode ==> only one selected path
+        TreePath path = e.getNewLeadSelectionPath();
 
-          // Update the detailsUI (if necessary)
-          updateDetailsUI(path);
+        // Update the detailsUI (if necessary)
+        updateDetailsUI(path);
 
-          // Restore the divider location, changing of the displayed components could have changed
-          // it
-          detailsSplitpane.setDividerLocation(divLocation);
-        }
+        // Restore the divider location, changing of the displayed components could have changed
+        // it
+        detailsSplitpane.setDividerLocation(divLocation);
+      };
 
-        /**
-         * Updates the detailsUI, if necessary.
-         *
-         * @param path The path pointing to the selected node
-         */
-        private void updateDetailsUI(TreePath path) {
-          if (path != null) {
-            DefaultMutableTreeNode selectedNode =
-                (DefaultMutableTreeNode) path.getLastPathComponent();
-            if (selectedNode != null) {
-              Object userObj = selectedNode.getUserObject();
-              if (userObj != null) {
-                if (userObj instanceof FeatureNode) {
-                  String details = ((FeatureNode) userObj).getDetails();
-                  String[][] detailsArray = ((FeatureNode) userObj).getDetailsArray();
-                  Component detailsComp = ((FeatureNode) userObj).getDetailsUI();
-                  if (details != null) {
-                    detailsUI.setText(details);
-                  } else if (detailsArray != null) {
-                    detailsSplitpane.setRightComponent(new LabelValuePanel(detailsArray));
-                  } else if (detailsComp != null) {
-                    detailsSplitpane.setRightComponent(detailsComp);
-                  }
-                } else if (userObj instanceof ChangeNode) {
-                  // ChangeNode creates the component on the fly for us
-                  Component detailsComp = ((ChangeNode) userObj).getDetailsUI();
-                  detailsSplitpane.setRightComponent(detailsComp);
-                }
-              }
+  /**
+   * Updates the detailsUI, if necessary.
+   *
+   * @param path The path pointing to the selected node
+   */
+  private void updateDetailsUI(TreePath path) {
+    if (path != null) {
+      DefaultMutableTreeNode selectedNode = (DefaultMutableTreeNode) path.getLastPathComponent();
+      if (selectedNode != null) {
+        Object userObj = selectedNode.getUserObject();
+        if (userObj != null) {
+          if (userObj instanceof FeatureNode) {
+            String details = ((FeatureNode) userObj).getDetails();
+            String[][] detailsArray = ((FeatureNode) userObj).getDetailsArray();
+            Component detailsComp = ((FeatureNode) userObj).getDetailsUI();
+            if (details != null) {
+              detailsUI.setText(details);
+            } else if (detailsArray != null) {
+              detailsSplitpane.setRightComponent(new LabelValuePanel(detailsArray));
+            } else if (detailsComp != null) {
+              detailsSplitpane.setRightComponent(detailsComp);
             }
+          } else if (userObj instanceof ChangeNode) {
+            // ChangeNode creates the component on the fly for us
+            Component detailsComp = ((ChangeNode) userObj).getDetailsUI();
+            detailsSplitpane.setRightComponent(detailsComp);
           }
         }
-      };
+      }
+    }
+  }
 
   /** The actual changeDataSet. */
   private TreeChangeDataSet actualChangeDataSet = null;
@@ -262,24 +257,18 @@ public class ChangeTree extends ChangeComponent {
     simpleEChangeTextBox = new JCheckBox("Simple EChange text", SIMPLE_ECHANGE_TEXT_DEFAULT_VALUE);
     simpleEChangeTextBox.setFont(ChangeVisualizationUI.DEFAULT_CHECKBOX_FONT);
     simpleEChangeTextBox.addActionListener(
-        new ActionListener() {
-          @Override
-          public void actionPerformed(ActionEvent e) {
-            boolean simpleEChangeText = ((JCheckBox) e.getSource()).isSelected();
-            updateSimpleEChangeText(simpleEChangeText);
-          }
+        e -> {
+          boolean simpleEChangeText = ((JCheckBox) e.getSource()).isSelected();
+          updateSimpleEChangeText(simpleEChangeText);
         });
     toolbar.add(simpleEChangeTextBox);
 
     showIDTextBox = new JCheckBox("Show IDs", SHOW_ID_DEFAULT_VALUE);
     showIDTextBox.setFont(ChangeVisualizationUI.DEFAULT_CHECKBOX_FONT);
     showIDTextBox.addActionListener(
-        new ActionListener() {
-          @Override
-          public void actionPerformed(ActionEvent e) {
-            boolean showID = ((JCheckBox) e.getSource()).isSelected();
-            updateShowID(showID);
-          }
+        e -> {
+          boolean showID = ((JCheckBox) e.getSource()).isSelected();
+          updateShowID(showID);
         });
     toolbar.add(showIDTextBox);
   }
@@ -389,21 +378,18 @@ public class ChangeTree extends ChangeComponent {
 
     // Create listener
     ActionListener behaviorListener =
-        new ActionListener() {
-          @Override
-          public void actionPerformed(ActionEvent e) {
-            if (((JCheckBox) e.getSource()).isSelected()) {
-              if (expandPChange == e.getSource()) {
-                expandBehavior = ExpandBehavior.EXPAND_PROPAGATED_CHANGES;
-              } else if (expandVChange == e.getSource()) {
-                expandBehavior = ExpandBehavior.EXPAND_VCHANGES;
-              } else if (expandEChange == e.getSource()) {
-                expandBehavior = ExpandBehavior.EXPAND_ECHANGES;
-              }
-              expandNodes();
-            } else {
-              // we react only to the selection
+        e -> {
+          if (((JCheckBox) e.getSource()).isSelected()) {
+            if (expandPChange == e.getSource()) {
+              expandBehavior = ExpandBehavior.EXPAND_PROPAGATED_CHANGES;
+            } else if (expandVChange == e.getSource()) {
+              expandBehavior = ExpandBehavior.EXPAND_VCHANGES;
+            } else if (expandEChange == e.getSource()) {
+              expandBehavior = ExpandBehavior.EXPAND_ECHANGES;
             }
+            expandNodes();
+          } else {
+            // we react only to the selection
           }
         };
 
@@ -421,7 +407,7 @@ public class ChangeTree extends ChangeComponent {
   @Override
   public void setData(ChangeDataSet changeDataSet) {
     if (!(changeDataSet instanceof TreeChangeDataSet)) {
-      throw new RuntimeException("Invalid ChangeDataSet");
+      throw new IllegalArgumentException("Invalid ChangeDataSet");
     }
 
     // If something visualized so far, store its state
@@ -514,10 +500,10 @@ public class ChangeTree extends ChangeComponent {
   public List<String> determineHighlightedCdsIds(
       String highlightID, List<ChangeDataSet> changeDataSets) {
     if (highlightID == null) {
-      return null;
+      return Collections.emptyList();
     }
     if (changeDataSets == null) {
-      return null;
+      return Collections.emptyList();
     }
     List<String> highlightedCdsIds = new Vector<String>();
 

--- a/testutils/changevisualization/src/main/java/tools/vitruv/change/testutils/changevisualization/tree/ChangeTree.java
+++ b/testutils/changevisualization/src/main/java/tools/vitruv/change/testutils/changevisualization/tree/ChangeTree.java
@@ -204,6 +204,22 @@ public class ChangeTree extends ChangeComponent {
         });
   }
 
+  public JTree getTreeUI() {
+    return treeUI;
+  }
+
+  public JTextArea getDetailsUI() {
+    return detailsUI;
+  }
+
+  public JSplitPane getDetailsSplitpane() {
+    return detailsSplitpane;
+  }
+
+  public JScrollPane getTreeScroller() {
+    return treeScroller;
+  }
+
   /** Sets the enabled state of the ChangeTree. */
   @Override
   public void setEnabled(boolean isEnabled) {

--- a/testutils/changevisualization/src/test/java/tools/vitruv/change/testutils/changevisualization/tree/ChangeTreeUnitTest.java
+++ b/testutils/changevisualization/src/test/java/tools/vitruv/change/testutils/changevisualization/tree/ChangeTreeUnitTest.java
@@ -7,10 +7,15 @@ import java.awt.event.InputEvent;
 import java.awt.event.MouseWheelEvent;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
+import javax.swing.JLabel;
 import javax.swing.JSplitPane;
 import javax.swing.SwingUtilities;
+import javax.swing.tree.DefaultMutableTreeNode;
+import javax.swing.tree.DefaultTreeModel;
+import javax.swing.tree.TreePath;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import tools.vitruv.change.testutils.changevisualization.ui.LabelValuePanel;
 
 class ChangeTreeUnitTest {
 
@@ -65,6 +70,62 @@ class ChangeTreeUnitTest {
           assertThat(changeTree.getDetailsUI()).isNotNull();
           assertThat(changeTree.getTreeScroller()).isNotNull();
           assertThat(changeTree.getDetailsSplitpane()).isNotNull();
+        });
+  }
+
+  @Test
+  void selectingFeatureNodeWithTextDetails_updatesDetailsText() throws Exception {
+    SwingUtilities.invokeAndWait(
+        () -> {
+          selectNode(new FeatureNode("feature", "value", "detail text", null, null));
+
+          assertThat(changeTree.getDetailsUI().getText()).isEqualTo("detail text");
+        });
+  }
+
+  @Test
+  void selectingFeatureNodeWithArrayDetails_updatesDetailsComponent() throws Exception {
+    SwingUtilities.invokeAndWait(
+        () -> {
+          String[][] detailsArray = new String[][] {{"label", "value"}};
+
+          selectNode(new FeatureNode("feature", "value", null, detailsArray, null));
+
+          assertThat(changeTree.getDetailsSplitpane().getRightComponent())
+              .isInstanceOf(LabelValuePanel.class);
+        });
+  }
+
+  @Test
+  void selectingFeatureNodeWithCustomDetailsComponent_updatesDetailsComponent() throws Exception {
+    SwingUtilities.invokeAndWait(
+        () -> {
+          JLabel detailsComponent = new JLabel("details");
+
+          selectNode(new FeatureNode("feature", "value", null, null, detailsComponent));
+
+          assertThat(changeTree.getDetailsSplitpane().getRightComponent())
+              .isSameAs(detailsComponent);
+        });
+  }
+
+  @Test
+  void selectingChangeNode_updatesDetailsComponent() throws Exception {
+    SwingUtilities.invokeAndWait(
+        () -> {
+          ChangeNode changeNode =
+              new ChangeNode(
+                  "individual change",
+                  new String[][] {{"feature", "value"}},
+                  ChangeNode.EChangeClass.ATTRIBUTE_ECHANGE,
+                  "ChangeClass",
+                  "AffectedClass",
+                  "id");
+
+          selectNode(changeNode);
+
+          assertThat(changeTree.getDetailsSplitpane().getRightComponent())
+              .isInstanceOf(LabelValuePanel.class);
         });
   }
 
@@ -136,6 +197,15 @@ class ChangeTreeUnitTest {
         .as("tsl holds a non-serializable TreeSelectionListener and must be transient "
             + "to avoid NotSerializableException (SonarCloud java:S1948)")
         .isTrue();
+  }
+
+  private void selectNode(Object userObject) {
+    DefaultMutableTreeNode root = new DefaultMutableTreeNode("root");
+    DefaultMutableTreeNode child = new DefaultMutableTreeNode(userObject);
+    root.add(child);
+
+    changeTree.getTreeUI().setModel(new DefaultTreeModel(root));
+    changeTree.getTreeUI().setSelectionPath(new TreePath(new Object[] {root, child}));
   }
 
   private void simulateCtrlMouseWheel(int rotation) {


### PR DESCRIPTION
## Description

This PR started from the Sonar issue requiring `Collections.emptyList()` to be returned instead of `null`.

While working on that issue, I noticed that Sonar also had additional maintainability issues in the same file, `ChangeTree.java`. I included those fixes in this PR so the file is cleaned up instead of leaving related Sonar findings unresolved.

## Changes

- Returns `Collections.emptyList()` instead of `null`.
- Replaces a generic `RuntimeException` with `IllegalArgumentException`.
- Converts single-method anonymous listener classes to lambdas.
- Extracts tree-selection detail handling into helper methods to reduce cognitive complexity.
- Adds focused unit coverage for the detail-rendering paths.