### PR TITLE
Document the intentionally-empty setTarget of NotificationRecorder in ChangeRecorder

### DIFF
--- a/composite/src/main/java/tools/vitruv/change/composite/recording/ChangeRecorder.java
+++ b/composite/src/main/java/tools/vitruv/change/composite/recording/ChangeRecorder.java
@@ -267,6 +267,9 @@ public class ChangeRecorder implements AutoCloseable {
 
     @Override
     public void setTarget(final Notifier newTarget) {
+      // Intentionally empty: this recorder does not track a single adapter target
+      // (getTarget() always returns null). It is attached to and detached from notifiers
+      // explicitly by the enclosing ChangeRecorder, so EMF's target callback needs no action.
     }
 
     public NotificationRecorder(final ChangeRecorder outer) {


### PR DESCRIPTION
Fixes #478

`NotificationRecorder` (the inner EMF `Adapter` used by `ChangeRecorder`) implemented `setTarget(Notifier)` with an empty body, giving no indication of whether the emptiness was intentional (SonarCloud `java:S1186`, HIGH).

## Why document rather than throw
This adapter deliberately does not participate in EMF's normal target tracking: `getTarget()` always returns `null` and `isAdapterForType(...)` returns `false`. The recorder is attached to and detached from notifiers explicitly by the enclosing `ChangeRecorder`. EMF still calls `setTarget` when the adapter is added to a notifier's `eAdapters`, so it must remain a callable no-op — throwing would break recording. The "document or throw" choice is therefore resolved by documenting.

## Fix
Add a comment to `setTarget` explaining that it is intentionally a no-op.

## Verification
- `composite` compiles.
- The change is comment-only, so behaviour is unchanged; `ChangeRecorderTest` (which attaches this adapter while recording) continues to exercise it.
- The changed lines are checkstyle-clean.
