### PR TITLE
Resolve Sonar maintainability issues in test utilities

### DIFF
--- a/testutils/changevisualization/src/main/java/tools/vitruv/change/testutils/changevisualization/tree/decoder/TreeChangeDataSetDecoder.java
+++ b/testutils/changevisualization/src/main/java/tools/vitruv/change/testutils/changevisualization/tree/decoder/TreeChangeDataSetDecoder.java
@@ -231,7 +231,7 @@ public class TreeChangeDataSetDecoder {
         break;
       default:
         // this should never happens
-        throw new RuntimeException("Unknown change type : " + changeType);
+        throw new IllegalArgumentException("Unknown change type : " + changeType);
     }
 
     return node;


### PR DESCRIPTION
## Summary

- Replaced a generic `RuntimeException` in `TreeChangeDataSetDecoder` with `IllegalArgumentException` for unsupported change types.