### PR TITLE
Replace Throwable catches in model printer setup

### DIFF
--- a/testutils/core/src/main/java/tools/vitruv/change/testutils/printing/ModelPrinterChange.java
+++ b/testutils/core/src/main/java/tools/vitruv/change/testutils/printing/ModelPrinterChange.java
@@ -48,36 +48,21 @@ public class ModelPrinterChange implements BeforeAllCallback, BeforeEachCallback
     }
     final Function<Class<? extends ModelPrinter>, ModelPrinter> _function = (
         Class<? extends ModelPrinter> printerClass) -> {
-      try {
-        ModelPrinter _xblockexpression = null;
-        {
-          final Constructor<?> constructor = Arrays.stream(printerClass.getConstructors())
-              .filter(it -> it.getParameterCount() == 0).findFirst().orElse(null);
-          Preconditions.checkArgument((constructor != null), printerClass + " has no zero-arg constructor!");
-          ModelPrinter _xtrycatchfinallyexpression = null;
-          try {
-            Object _newInstance = constructor.newInstance();
-            _xtrycatchfinallyexpression = ((ModelPrinter) _newInstance);
-          } catch (final Throwable _t) {
-            if (_t instanceof RuntimeException) {
-              final RuntimeException e = (RuntimeException) _t;
-              throw new IllegalStateException("Failed to create an instance of " + printerClass + "!", e);
-            } else if (_t instanceof Error) {
-              throw (Error) _t;
-            } else {
-              throw new RuntimeException(_t);
-            }
-          }
-          _xblockexpression = _xtrycatchfinallyexpression;
+      ModelPrinter _xblockexpression = null;
+      {
+        final Constructor<?> constructor = Arrays.stream(printerClass.getConstructors())
+            .filter(it -> it.getParameterCount() == 0).findFirst().orElse(null);
+        Preconditions.checkArgument((constructor != null), printerClass + " has no zero-arg constructor!");
+        ModelPrinter _xtrycatchfinallyexpression = null;
+        try {
+          Object _newInstance = constructor.newInstance();
+          _xtrycatchfinallyexpression = ((ModelPrinter) _newInstance);
+        } catch (final Exception e) {
+          throw new IllegalStateException("Failed to create an instance of " + printerClass + "!", e);
         }
-        return _xblockexpression;
-      } catch (Throwable _e) {
-        if (_e instanceof RuntimeException)
-          throw (RuntimeException) _e;
-        if (_e instanceof Error)
-          throw (Error) _e;
-        throw new RuntimeException(_e);
+        _xblockexpression = _xtrycatchfinallyexpression;
       }
+      return _xblockexpression;
     };
     final List<ModelPrinter> printers = Arrays.stream(annotation.get().value()).map(_function)
         .collect(Collectors.toList());

--- a/testutils/core/src/main/java/tools/vitruv/change/testutils/printing/ModelPrinterChange.java
+++ b/testutils/core/src/main/java/tools/vitruv/change/testutils/printing/ModelPrinterChange.java
@@ -48,21 +48,23 @@ public class ModelPrinterChange implements BeforeAllCallback, BeforeEachCallback
     }
     final Function<Class<? extends ModelPrinter>, ModelPrinter> _function = (
         Class<? extends ModelPrinter> printerClass) -> {
-      ModelPrinter _xblockexpression = null;
+      ModelPrinter modelPrinter = null;
       {
         final Constructor<?> constructor = Arrays.stream(printerClass.getConstructors())
             .filter(it -> it.getParameterCount() == 0).findFirst().orElse(null);
-        Preconditions.checkArgument((constructor != null), printerClass + " has no zero-arg constructor!");
-        ModelPrinter _xtrycatchfinallyexpression = null;
+        Preconditions.checkArgument(
+            constructor != null, printerClass + " has no zero-arg constructor!");
+        ModelPrinter constructedPrinter = null;
         try {
-          Object _newInstance = constructor.newInstance();
-          _xtrycatchfinallyexpression = ((ModelPrinter) _newInstance);
+          Object newInstance = constructor.newInstance();
+          constructedPrinter = ((ModelPrinter) newInstance);
         } catch (final Exception e) {
-          throw new IllegalStateException("Failed to create an instance of " + printerClass + "!", e);
+          throw new IllegalStateException(
+              "Failed to create an instance of " + printerClass + "!", e);
         }
-        _xblockexpression = _xtrycatchfinallyexpression;
+        modelPrinter = constructedPrinter;
       }
-      return _xblockexpression;
+      return modelPrinter;
     };
     final List<ModelPrinter> printers = Arrays.stream(annotation.get().value()).map(_function)
         .collect(Collectors.toList());


### PR DESCRIPTION
## Summary

Fixes the Sonar `java:S1181` issue in `ModelPrinterChange` by avoiding `Throwable` handling during model printer instantiation.

## Changes

- Replaced the `Throwable` catch around reflective constructor invocation with `Exception`.
- Removed the outer `Throwable` wrapper that would still trigger the same Sonar rule.
- Preserved the existing printer construction flow.