### PR TITLE
499 refactor this method to reduce its cognitive complexity in printresultextensionjava class

### DIFF
--- a/testutils/core/src/main/java/tools/vitruv/change/testutils/matchers/ModelDeepEqualityMatcher.java
+++ b/testutils/core/src/main/java/tools/vitruv/change/testutils/matchers/ModelDeepEqualityMatcher.java
@@ -422,9 +422,9 @@ class ModelDeepEqualityMatcher<O extends EObject> extends TypeSafeMatcher<O> {
       }
       PrintResult plus1 = PrintResultExtension.operatorPlus(_print, _xifexpression);
       PrintResult _print_3 = target.print(".");
-      PrintResult _plus_2 = PrintResultExtension.operatorPlus(plus1, _print_3);
+      PrintResult plus2 = PrintResultExtension.operatorPlus(plus1, _print_3);
       PrintResult _print_4 = target.print(feature.getName());
-      PrintResult plus3 = PrintResultExtension.operatorPlus(_plus_2, _print_4);
+      PrintResult plus3 = PrintResultExtension.operatorPlus(plus2, _print_4);
       PrintResult _print_5 = target.print(" ");
       PrintResult plus4 = PrintResultExtension.operatorPlus(plus3, _print_5);
       PrintResult print6 = target.print(this.getVerb(difference.getKind()));

--- a/testutils/core/src/main/java/tools/vitruv/change/testutils/matchers/ModelDeepEqualityMatcher.java
+++ b/testutils/core/src/main/java/tools/vitruv/change/testutils/matchers/ModelDeepEqualityMatcher.java
@@ -414,23 +414,23 @@ class ModelDeepEqualityMatcher<O extends EObject> extends TypeSafeMatcher<O> {
         PrintResult _print_1 = target.print(" (");
         PrintResult _printObjectShortened = this.modelPrinter.printObjectShortened(target, this.idProvider,
             difference.getMatch().getLeft());
-        PrintResult _plus = PrintResultExtension.operatorPlus(_print_1, _printObjectShortened);
+        PrintResult plus = PrintResultExtension.operatorPlus(_print_1, _printObjectShortened);
         PrintResult _print_2 = target.print(")");
-        _xifexpression = PrintResultExtension.operatorPlus(_plus, _print_2);
+        _xifexpression = PrintResultExtension.operatorPlus(plus, _print_2);
       } else {
         _xifexpression = PrintResult.PRINTED_NO_OUTPUT;
       }
-      PrintResult _plus_1 = PrintResultExtension.operatorPlus(_print, _xifexpression);
+      PrintResult plus1 = PrintResultExtension.operatorPlus(_print, _xifexpression);
       PrintResult _print_3 = target.print(".");
-      PrintResult _plus_2 = PrintResultExtension.operatorPlus(_plus_1, _print_3);
+      PrintResult _plus_2 = PrintResultExtension.operatorPlus(plus1, _print_3);
       PrintResult _print_4 = target.print(feature.getName());
-      PrintResult _plus_3 = PrintResultExtension.operatorPlus(_plus_2, _print_4);
+      PrintResult plus3 = PrintResultExtension.operatorPlus(_plus_2, _print_4);
       PrintResult _print_5 = target.print(" ");
-      PrintResult _plus_4 = PrintResultExtension.operatorPlus(_plus_3, _print_5);
-      PrintResult _print_6 = target.print(this.getVerb(difference.getKind()));
-      PrintResult _plus_5 = PrintResultExtension.operatorPlus(_plus_4, _print_6);
-      PrintResult _print_7 = target.print(": ");
-      PrintResult _plus_6 = PrintResultExtension.operatorPlus(_plus_5, _print_7);
+      PrintResult plus4 = PrintResultExtension.operatorPlus(plus3, _print_5);
+      PrintResult print6 = target.print(this.getVerb(difference.getKind()));
+      PrintResult plus5 = PrintResultExtension.operatorPlus(plus4, print6);
+      PrintResult print7 = target.print(": ");
+      PrintResult plus6 = PrintResultExtension.operatorPlus(plus5, print7);
       EObject _elvis = null;
       EObject _left_1 = difference.getMatch().getLeft();
       if (_left_1 != null) {
@@ -441,7 +441,7 @@ class ModelDeepEqualityMatcher<O extends EObject> extends TypeSafeMatcher<O> {
       }
       PrintResult _printFeatureValue = this.modelPrinter.printFeatureValue(target, this.idProvider, _elvis, feature,
           value);
-      return PrintResultExtension.operatorPlus(_plus_6, _printFeatureValue);
+      return PrintResultExtension.operatorPlus(plus6, _printFeatureValue);
     }
 
     private String getVerb(final DifferenceKind kind) {

--- a/testutils/core/src/main/java/tools/vitruv/change/testutils/matchers/ModelDeepEqualityMatcher.java
+++ b/testutils/core/src/main/java/tools/vitruv/change/testutils/matchers/ModelDeepEqualityMatcher.java
@@ -401,7 +401,7 @@ class ModelDeepEqualityMatcher<O extends EObject> extends TypeSafeMatcher<O> {
       if (!_matched) {
         _switchResult = this.modelPrinter.printObject(target, this.idProvider, difference);
       }
-      return PrintResultExtension.operator_plus(_print, _switchResult);
+      return PrintResultExtension.operatorPlus(_print, _switchResult);
     }
 
     private PrintResult printFeatureDifference(final PrintTarget target, final EStructuralFeature feature,
@@ -414,23 +414,23 @@ class ModelDeepEqualityMatcher<O extends EObject> extends TypeSafeMatcher<O> {
         PrintResult _print_1 = target.print(" (");
         PrintResult _printObjectShortened = this.modelPrinter.printObjectShortened(target, this.idProvider,
             difference.getMatch().getLeft());
-        PrintResult _plus = PrintResultExtension.operator_plus(_print_1, _printObjectShortened);
+        PrintResult _plus = PrintResultExtension.operatorPlus(_print_1, _printObjectShortened);
         PrintResult _print_2 = target.print(")");
-        _xifexpression = PrintResultExtension.operator_plus(_plus, _print_2);
+        _xifexpression = PrintResultExtension.operatorPlus(_plus, _print_2);
       } else {
         _xifexpression = PrintResult.PRINTED_NO_OUTPUT;
       }
-      PrintResult _plus_1 = PrintResultExtension.operator_plus(_print, _xifexpression);
+      PrintResult _plus_1 = PrintResultExtension.operatorPlus(_print, _xifexpression);
       PrintResult _print_3 = target.print(".");
-      PrintResult _plus_2 = PrintResultExtension.operator_plus(_plus_1, _print_3);
+      PrintResult _plus_2 = PrintResultExtension.operatorPlus(_plus_1, _print_3);
       PrintResult _print_4 = target.print(feature.getName());
-      PrintResult _plus_3 = PrintResultExtension.operator_plus(_plus_2, _print_4);
+      PrintResult _plus_3 = PrintResultExtension.operatorPlus(_plus_2, _print_4);
       PrintResult _print_5 = target.print(" ");
-      PrintResult _plus_4 = PrintResultExtension.operator_plus(_plus_3, _print_5);
+      PrintResult _plus_4 = PrintResultExtension.operatorPlus(_plus_3, _print_5);
       PrintResult _print_6 = target.print(this.getVerb(difference.getKind()));
-      PrintResult _plus_5 = PrintResultExtension.operator_plus(_plus_4, _print_6);
+      PrintResult _plus_5 = PrintResultExtension.operatorPlus(_plus_4, _print_6);
       PrintResult _print_7 = target.print(": ");
-      PrintResult _plus_6 = PrintResultExtension.operator_plus(_plus_5, _print_7);
+      PrintResult _plus_6 = PrintResultExtension.operatorPlus(_plus_5, _print_7);
       EObject _elvis = null;
       EObject _left_1 = difference.getMatch().getLeft();
       if (_left_1 != null) {
@@ -441,7 +441,7 @@ class ModelDeepEqualityMatcher<O extends EObject> extends TypeSafeMatcher<O> {
       }
       PrintResult _printFeatureValue = this.modelPrinter.printFeatureValue(target, this.idProvider, _elvis, feature,
           value);
-      return PrintResultExtension.operator_plus(_plus_6, _printFeatureValue);
+      return PrintResultExtension.operatorPlus(_plus_6, _printFeatureValue);
     }
 
     private String getVerb(final DifferenceKind kind) {

--- a/testutils/core/src/main/java/tools/vitruv/change/testutils/printing/DefaultModelPrinter.java
+++ b/testutils/core/src/main/java/tools/vitruv/change/testutils/printing/DefaultModelPrinter.java
@@ -115,7 +115,7 @@ public final class DefaultModelPrinter implements ModelPrinter {
     }
     PrintResult _print = target.print(feature.getName());
     PrintResult _print_1 = target.print("=");
-    PrintResult _plus = PrintResultExtension.operatorPlus(_print, _print_1);
+    PrintResult plus = PrintResultExtension.operatorPlus(_print, _print_1);
     PrintResult _xifexpression = null;
     boolean _isMany = feature.isMany();
     if (_isMany) {
@@ -134,7 +134,7 @@ public final class DefaultModelPrinter implements ModelPrinter {
     } else {
       _xifexpression = this.subPrinter.printFeatureValue(target, idProvider, object, feature, object.eGet(feature));
     }
-    return PrintResultExtension.operatorPlus(_plus, _xifexpression);
+    return PrintResultExtension.operatorPlus(plus, _xifexpression);
   }
 
   @Override

--- a/testutils/core/src/main/java/tools/vitruv/change/testutils/printing/DefaultModelPrinter.java
+++ b/testutils/core/src/main/java/tools/vitruv/change/testutils/printing/DefaultModelPrinter.java
@@ -45,12 +45,12 @@ public final class DefaultModelPrinter implements ModelPrinter {
       return this.subPrinter.printObject(subTarget, idProvider, uri);
     };
     PrintResult _printValue = target.<URI>printValue(resource.getURI(), _function);
-    PrintResult _plus = PrintResultExtension.operatorPlus(_print, _printValue);
+    PrintResult plus = PrintResultExtension.operatorPlus(_print, _printValue);
     final BiFunction<PrintTarget, EObject, PrintResult> _function_1 = (PrintTarget subTarget, EObject element) -> {
       return this.subPrinter.printObject(subTarget, idProvider, element);
     };
     PrintResult _printList = target.<EObject>printList(resource.getContents(), PrintMode.MULTI_LINE_LIST, _function_1);
-    return PrintResultExtension.operatorPlus(_plus, _printList);
+    return PrintResultExtension.operatorPlus(plus, _printList);
   }
 
   private PrintResult _dispatchPrintObject(final PrintTarget target, final PrintIdProvider idProvider,
@@ -79,14 +79,14 @@ public final class DefaultModelPrinter implements ModelPrinter {
       } else {
         _xifexpression_1 = PrintResult.PRINTED_NO_OUTPUT;
       }
-      PrintResult _plus_1 = PrintResultExtension.operatorPlus(_print, _xifexpression_1);
+      PrintResult plus1 = PrintResultExtension.operatorPlus(_print, _xifexpression_1);
       final BiFunction<PrintTarget, EStructuralFeature, PrintResult> _function_1 = (PrintTarget subTarget,
           EStructuralFeature feature) -> {
         return this.subPrinter.printFeature(subTarget, idProvider, object, feature);
       };
       PrintResult _printIterable = target.<EStructuralFeature>printIterable("(", ")", featuresToPrint,
           DefaultModelPrinter.FEATURE_PRINT_MODE, _function_1);
-      _xblockexpression = PrintResultExtension.operatorPlus(_plus_1, _printIterable);
+      _xblockexpression = PrintResultExtension.operatorPlus(plus1, _printIterable);
     }
     return _xblockexpression;
   }
@@ -192,12 +192,12 @@ public final class DefaultModelPrinter implements ModelPrinter {
       return this.subPrinter.printObjectShortened(subTarget, idProvider, uri);
     };
     PrintResult _printValue = target.<URI>printValue(resource.getURI(), _function);
-    PrintResult _plus = PrintResultExtension.operatorPlus(_print, _printValue);
+    PrintResult plus = PrintResultExtension.operatorPlus(_print, _printValue);
     final BiFunction<PrintTarget, EObject, PrintResult> _function_1 = (PrintTarget subTarget, EObject element) -> {
       return this.subPrinter.printObjectShortened(subTarget, idProvider, element);
     };
     PrintResult _printList = target.<EObject>printList(resource.getContents(), PrintMode.SINGLE_LINE_LIST, _function_1);
-    return PrintResultExtension.operatorPlus(_plus, _printList);
+    return PrintResultExtension.operatorPlus(plus, _printList);
   }
 
   private PrintResult _dispatchPrintObjectShortened(final PrintTarget target,
@@ -210,9 +210,9 @@ public final class DefaultModelPrinter implements ModelPrinter {
       if ((idAttribute != null)) {
         PrintResult _print_1 = target.print("(");
         PrintResult _printFeature = this.printFeature(target, idProvider, object, idAttribute);
-        PrintResult _plus = PrintResultExtension.operatorPlus(_print_1, _printFeature);
+        PrintResult plus = PrintResultExtension.operatorPlus(_print_1, _printFeature);
         PrintResult _print_2 = target.print(")");
-        _xifexpression = PrintResultExtension.operatorPlus(_plus, _print_2);
+        _xifexpression = PrintResultExtension.operatorPlus(plus, _print_2);
       } else {
         PrintResult _print_3 = target.print("#");
         PrintResult _print_4 = target.print(idProvider.getFallbackId(object));
@@ -261,9 +261,9 @@ public final class DefaultModelPrinter implements ModelPrinter {
     if (!_matched) {
       PrintResult _print = target.print(object.getClass().getSimpleName());
       PrintResult _print_1 = target.print("#");
-      PrintResult _plus = PrintResultExtension.operatorPlus(_print, _print_1);
+      PrintResult plus = PrintResultExtension.operatorPlus(_print, _print_1);
       PrintResult _print_2 = target.print(idProvider.getFallbackId(object));
-      _switchResult = PrintResultExtension.operatorPlus(_plus, _print_2);
+      _switchResult = PrintResultExtension.operatorPlus(plus, _print_2);
     }
     return _switchResult;
   }

--- a/testutils/core/src/main/java/tools/vitruv/change/testutils/printing/DefaultModelPrinter.java
+++ b/testutils/core/src/main/java/tools/vitruv/change/testutils/printing/DefaultModelPrinter.java
@@ -45,12 +45,12 @@ public final class DefaultModelPrinter implements ModelPrinter {
       return this.subPrinter.printObject(subTarget, idProvider, uri);
     };
     PrintResult _printValue = target.<URI>printValue(resource.getURI(), _function);
-    PrintResult _plus = PrintResultExtension.operator_plus(_print, _printValue);
+    PrintResult _plus = PrintResultExtension.operatorPlus(_print, _printValue);
     final BiFunction<PrintTarget, EObject, PrintResult> _function_1 = (PrintTarget subTarget, EObject element) -> {
       return this.subPrinter.printObject(subTarget, idProvider, element);
     };
     PrintResult _printList = target.<EObject>printList(resource.getContents(), PrintMode.MULTI_LINE_LIST, _function_1);
-    return PrintResultExtension.operator_plus(_plus, _printList);
+    return PrintResultExtension.operatorPlus(_plus, _printList);
   }
 
   private PrintResult _dispatchPrintObject(final PrintTarget target, final PrintIdProvider idProvider,
@@ -75,18 +75,18 @@ public final class DefaultModelPrinter implements ModelPrinter {
       if ((idAttribute == null)) {
         PrintResult _print_1 = target.print("#");
         PrintResult _print_2 = target.print(idProvider.getFallbackId(object));
-        _xifexpression_1 = PrintResultExtension.operator_plus(_print_1, _print_2);
+        _xifexpression_1 = PrintResultExtension.operatorPlus(_print_1, _print_2);
       } else {
         _xifexpression_1 = PrintResult.PRINTED_NO_OUTPUT;
       }
-      PrintResult _plus_1 = PrintResultExtension.operator_plus(_print, _xifexpression_1);
+      PrintResult _plus_1 = PrintResultExtension.operatorPlus(_print, _xifexpression_1);
       final BiFunction<PrintTarget, EStructuralFeature, PrintResult> _function_1 = (PrintTarget subTarget,
           EStructuralFeature feature) -> {
         return this.subPrinter.printFeature(subTarget, idProvider, object, feature);
       };
       PrintResult _printIterable = target.<EStructuralFeature>printIterable("(", ")", featuresToPrint,
           DefaultModelPrinter.FEATURE_PRINT_MODE, _function_1);
-      _xblockexpression = PrintResultExtension.operator_plus(_plus_1, _printIterable);
+      _xblockexpression = PrintResultExtension.operatorPlus(_plus_1, _printIterable);
     }
     return _xblockexpression;
   }
@@ -115,7 +115,7 @@ public final class DefaultModelPrinter implements ModelPrinter {
     }
     PrintResult _print = target.print(feature.getName());
     PrintResult _print_1 = target.print("=");
-    PrintResult _plus = PrintResultExtension.operator_plus(_print, _print_1);
+    PrintResult _plus = PrintResultExtension.operatorPlus(_print, _print_1);
     PrintResult _xifexpression = null;
     boolean _isMany = feature.isMany();
     if (_isMany) {
@@ -134,7 +134,7 @@ public final class DefaultModelPrinter implements ModelPrinter {
     } else {
       _xifexpression = this.subPrinter.printFeatureValue(target, idProvider, object, feature, object.eGet(feature));
     }
-    return PrintResultExtension.operator_plus(_plus, _xifexpression);
+    return PrintResultExtension.operatorPlus(_plus, _xifexpression);
   }
 
   @Override
@@ -192,12 +192,12 @@ public final class DefaultModelPrinter implements ModelPrinter {
       return this.subPrinter.printObjectShortened(subTarget, idProvider, uri);
     };
     PrintResult _printValue = target.<URI>printValue(resource.getURI(), _function);
-    PrintResult _plus = PrintResultExtension.operator_plus(_print, _printValue);
+    PrintResult _plus = PrintResultExtension.operatorPlus(_print, _printValue);
     final BiFunction<PrintTarget, EObject, PrintResult> _function_1 = (PrintTarget subTarget, EObject element) -> {
       return this.subPrinter.printObjectShortened(subTarget, idProvider, element);
     };
     PrintResult _printList = target.<EObject>printList(resource.getContents(), PrintMode.SINGLE_LINE_LIST, _function_1);
-    return PrintResultExtension.operator_plus(_plus, _printList);
+    return PrintResultExtension.operatorPlus(_plus, _printList);
   }
 
   private PrintResult _dispatchPrintObjectShortened(final PrintTarget target,
@@ -210,15 +210,15 @@ public final class DefaultModelPrinter implements ModelPrinter {
       if ((idAttribute != null)) {
         PrintResult _print_1 = target.print("(");
         PrintResult _printFeature = this.printFeature(target, idProvider, object, idAttribute);
-        PrintResult _plus = PrintResultExtension.operator_plus(_print_1, _printFeature);
+        PrintResult _plus = PrintResultExtension.operatorPlus(_print_1, _printFeature);
         PrintResult _print_2 = target.print(")");
-        _xifexpression = PrintResultExtension.operator_plus(_plus, _print_2);
+        _xifexpression = PrintResultExtension.operatorPlus(_plus, _print_2);
       } else {
         PrintResult _print_3 = target.print("#");
         PrintResult _print_4 = target.print(idProvider.getFallbackId(object));
-        _xifexpression = PrintResultExtension.operator_plus(_print_3, _print_4);
+        _xifexpression = PrintResultExtension.operatorPlus(_print_3, _print_4);
       }
-      _xblockexpression = PrintResultExtension.operator_plus(_print, _xifexpression);
+      _xblockexpression = PrintResultExtension.operatorPlus(_print, _xifexpression);
     }
     return _xblockexpression;
   }
@@ -231,7 +231,7 @@ public final class DefaultModelPrinter implements ModelPrinter {
     if (_greaterThan) {
       PrintResult _print = target.print(string.substring(0, 9));
       PrintResult _print_1 = target.print("…");
-      _xifexpression = PrintResultExtension.operator_plus(_print, _print_1);
+      _xifexpression = PrintResultExtension.operatorPlus(_print, _print_1);
     } else {
       _xifexpression = target.print(string);
     }
@@ -261,9 +261,9 @@ public final class DefaultModelPrinter implements ModelPrinter {
     if (!_matched) {
       PrintResult _print = target.print(object.getClass().getSimpleName());
       PrintResult _print_1 = target.print("#");
-      PrintResult _plus = PrintResultExtension.operator_plus(_print, _print_1);
+      PrintResult _plus = PrintResultExtension.operatorPlus(_print, _print_1);
       PrintResult _print_2 = target.print(idProvider.getFallbackId(object));
-      _switchResult = PrintResultExtension.operator_plus(_plus, _print_2);
+      _switchResult = PrintResultExtension.operatorPlus(_plus, _print_2);
     }
     return _switchResult;
   }

--- a/testutils/core/src/main/java/tools/vitruv/change/testutils/printing/DefaultPrintTarget.java
+++ b/testutils/core/src/main/java/tools/vitruv/change/testutils/printing/DefaultPrintTarget.java
@@ -139,7 +139,7 @@ public class DefaultPrintTarget implements PrintTarget {
     if (isEmpty) {
       PrintResult startResult = this.print(start);
       PrintResult endResult = this.print(end);
-      return PrintResultExtension.operator_plus(startResult, endResult);
+      return PrintResultExtension.operatorPlus(startResult, endResult);
     }
     int size = preprinted.size();
     int multiLineIfAtLeastItemCount = mode.getMultiLineIfAtLeastItemCount();
@@ -157,43 +157,43 @@ public class DefaultPrintTarget implements PrintTarget {
       {
         PrintResult _result = result;
         PrintResult _print = this.print(outputs.next());
-        result = PrintResultExtension.operator_plus(_result, _print);
+        result = PrintResultExtension.operatorPlus(_result, _print);
         boolean _hasNext = outputs.hasNext();
         if (_hasNext) {
           PrintResult _result_1 = result;
           PrintResult _print_1 = this.print(separator);
-          result = PrintResultExtension.operator_plus(_result_1, _print_1);
+          result = PrintResultExtension.operatorPlus(_result_1, _print_1);
         }
       }
     }
     PrintResult _print = this.print(end);
-    return PrintResultExtension.operator_plus(result, _print);
+    return PrintResultExtension.operatorPlus(result, _print);
   }
 
   private <T extends Object> PrintResult printMultiLine(final String start, final String end, final String separator,
       final Collection<DefaultPrintTarget> preprinted) {
     PrintResult _print = this.print(start);
     PrintResult _newLineIncreaseIndent = this.newLineIncreaseIndent();
-    PrintResult result = PrintResultExtension.operator_plus(_print, _newLineIncreaseIndent);
+    PrintResult result = PrintResultExtension.operatorPlus(_print, _newLineIncreaseIndent);
     for (final Iterator<DefaultPrintTarget> outputs = preprinted.iterator(); outputs.hasNext();) {
       {
         PrintResult _result = result;
         PrintResult _print_1 = this.print(outputs.next());
-        result = PrintResultExtension.operator_plus(_result, _print_1);
+        result = PrintResultExtension.operatorPlus(_result, _print_1);
         boolean _hasNext = outputs.hasNext();
         if (_hasNext) {
           PrintResult _result_1 = result;
           PrintResult _print_2 = this.print(separator);
           PrintResult _newLine = this.newLine();
-          PrintResult _plus = PrintResultExtension.operator_plus(_print_2, _newLine);
-          result = PrintResultExtension.operator_plus(_result_1, _plus);
+          PrintResult _plus = PrintResultExtension.operatorPlus(_print_2, _newLine);
+          result = PrintResultExtension.operatorPlus(_result_1, _plus);
         }
       }
     }
     PrintResult _newLineDecreaseIndent = this.newLineDecreaseIndent();
-    PrintResult _plus = PrintResultExtension.operator_plus(result, _newLineDecreaseIndent);
+    PrintResult _plus = PrintResultExtension.operatorPlus(result, _newLineDecreaseIndent);
     PrintResult _print_1 = this.print(end);
-    return PrintResultExtension.operator_plus(_plus, _print_1);
+    return PrintResultExtension.operatorPlus(_plus, _print_1);
   }
 
   @Override

--- a/testutils/core/src/main/java/tools/vitruv/change/testutils/printing/DefaultPrintTarget.java
+++ b/testutils/core/src/main/java/tools/vitruv/change/testutils/printing/DefaultPrintTarget.java
@@ -185,15 +185,15 @@ public class DefaultPrintTarget implements PrintTarget {
           PrintResult _result_1 = result;
           PrintResult _print_2 = this.print(separator);
           PrintResult _newLine = this.newLine();
-          PrintResult _plus = PrintResultExtension.operatorPlus(_print_2, _newLine);
-          result = PrintResultExtension.operatorPlus(_result_1, _plus);
+          PrintResult plus = PrintResultExtension.operatorPlus(_print_2, _newLine);
+          result = PrintResultExtension.operatorPlus(_result_1, plus);
         }
       }
     }
     PrintResult _newLineDecreaseIndent = this.newLineDecreaseIndent();
-    PrintResult _plus = PrintResultExtension.operatorPlus(result, _newLineDecreaseIndent);
+    PrintResult plus = PrintResultExtension.operatorPlus(result, _newLineDecreaseIndent);
     PrintResult _print_1 = this.print(end);
-    return PrintResultExtension.operatorPlus(_plus, _print_1);
+    return PrintResultExtension.operatorPlus(plus, _print_1);
   }
 
   @Override

--- a/testutils/core/src/main/java/tools/vitruv/change/testutils/printing/PrintResultExtension.java
+++ b/testutils/core/src/main/java/tools/vitruv/change/testutils/printing/PrintResultExtension.java
@@ -1,7 +1,6 @@
 package tools.vitruv.change.testutils.printing;
 
 import com.google.common.base.Preconditions;
-import java.util.function.Supplier;
 
 public final class PrintResultExtension {
   public static PrintResult operator_plus(final PrintResult previous, final PrintResult latest) {

--- a/testutils/core/src/main/java/tools/vitruv/change/testutils/printing/PrintResultExtension.java
+++ b/testutils/core/src/main/java/tools/vitruv/change/testutils/printing/PrintResultExtension.java
@@ -4,101 +4,35 @@ import com.google.common.base.Preconditions;
 import java.util.function.Supplier;
 
 public final class PrintResultExtension {
-  public static PrintResult operator_plus(final PrintResult a, final PrintResult b) {
-    PrintResult _xblockexpression = null;
-    {
-      Preconditions.<PrintResult>checkNotNull(a, "previous result");
-      Preconditions.<PrintResult>checkNotNull(b, "latest result");
-      PrintResult _switchResult = null;
-      if (a != null) {
-        switch (a) {
-          case PRINTED:
-            PrintResult _switchResult_1 = null;
-            if (b != null) {
-              switch (b) {
-                case PRINTED:
-                case PRINTED_NO_OUTPUT:
-                  _switchResult_1 = PrintResult.PRINTED;
-                  break;
-                case NOT_RESPONSIBLE:
-                  throw new IllegalStateException(
-                      "Got " + PrintResult.NOT_RESPONSIBLE + " after " + PrintResult.PRINTED + "!");
-                default:
-                  break;
-              }
-            }
-            _switchResult = _switchResult_1;
-            break;
-          case PRINTED_NO_OUTPUT:
-            PrintResult _switchResult_2 = null;
-            if (b != null) {
-              switch (b) {
-                case PRINTED_NO_OUTPUT:
-                  _switchResult_2 = PrintResult.PRINTED_NO_OUTPUT;
-                  break;
-                case NOT_RESPONSIBLE:
-                  _switchResult_2 = PrintResult.NOT_RESPONSIBLE;
-                  break;
-                case PRINTED:
-                  _switchResult_2 = PrintResult.PRINTED;
-                  break;
-                default:
-                  break;
-              }
-            }
-            _switchResult = _switchResult_2;
-            break;
-          case NOT_RESPONSIBLE:
-            PrintResult _switchResult_3 = null;
-            if (b != null) {
-              switch (b) {
-                case PRINTED:
-                  throw new IllegalStateException(
-                      "Got " + PrintResult.PRINTED + " after " + PrintResult.NOT_RESPONSIBLE + "!");
-                case PRINTED_NO_OUTPUT:
-                case NOT_RESPONSIBLE:
-                  _switchResult_3 = PrintResult.NOT_RESPONSIBLE;
-                  break;
-                default:
-                  break;
-              }
-            }
-            _switchResult = _switchResult_3;
-            break;
-          default:
-            break;
-        }
-      }
-      _xblockexpression = _switchResult;
+  public static PrintResult operator_plus(final PrintResult previous, final PrintResult latest) {
+    Preconditions.checkNotNull(previous, "previous result");
+    Preconditions.checkNotNull(latest, "latest result");
+
+    if (isInvalidTransition(previous, latest)) {
+      throw invalidTransition(previous, latest);
     }
-    return _xblockexpression;
+
+    if (previous == PrintResult.PRINTED || latest == PrintResult.PRINTED) {
+      return PrintResult.PRINTED;
+    }
+
+    if (previous == PrintResult.PRINTED_NO_OUTPUT
+            && latest == PrintResult.PRINTED_NO_OUTPUT) {
+      return PrintResult.PRINTED_NO_OUTPUT;
+    }
+
+    return PrintResult.NOT_RESPONSIBLE;
   }
 
-  public static PrintResult combine(final Iterable<? extends PrintResult> results) {
-    PrintResult acc = PrintResult.PRINTED_NO_OUTPUT;
-    for (PrintResult r : results) {
-      acc = PrintResultExtension.operator_plus(acc, r);
-    }
-    return acc;
+  private static boolean isInvalidTransition(
+          final PrintResult previous, final PrintResult latest) {
+    return previous == PrintResult.PRINTED && latest == PrintResult.NOT_RESPONSIBLE
+            || previous == PrintResult.NOT_RESPONSIBLE && latest == PrintResult.PRINTED;
   }
 
-  public static PrintResult appendIfPrinted(final PrintResult result, final Supplier<? extends PrintResult> printer) {
-    PrintResult _switchResult = null;
-    if (result != null) {
-      switch (result) {
-        case PRINTED:
-          PrintResult _apply = printer.get();
-          _switchResult = PrintResultExtension.operator_plus(result, _apply);
-          break;
-        case PRINTED_NO_OUTPUT:
-        case NOT_RESPONSIBLE:
-          _switchResult = result;
-          break;
-        default:
-          break;
-      }
-    }
-    return _switchResult;
+  private static IllegalStateException invalidTransition(
+          final PrintResult previous, final PrintResult latest) {
+    return new IllegalStateException("Got " + latest + " after " + previous + "!");
   }
 
   private PrintResultExtension() {

--- a/testutils/core/src/main/java/tools/vitruv/change/testutils/printing/PrintResultExtension.java
+++ b/testutils/core/src/main/java/tools/vitruv/change/testutils/printing/PrintResultExtension.java
@@ -3,7 +3,15 @@ package tools.vitruv.change.testutils.printing;
 import com.google.common.base.Preconditions;
 
 public final class PrintResultExtension {
-  public static PrintResult operator_plus(final PrintResult previous, final PrintResult latest) {
+  /**
+   * Combines a previous and latest print result.
+   *
+   * @param previous the previous print result
+   * @param latest the latest print result
+   * @return the combined print result
+   * @throws IllegalStateException if the transition between both results is invalid
+   */
+  public static PrintResult operatorPlus(final PrintResult previous, final PrintResult latest) {
     Preconditions.checkNotNull(previous, "previous result");
     Preconditions.checkNotNull(latest, "latest result");
 

--- a/testutils/core/src/main/java/tools/vitruv/change/testutils/printing/PrintTarget.java
+++ b/testutils/core/src/main/java/tools/vitruv/change/testutils/printing/PrintTarget.java
@@ -50,17 +50,17 @@ public interface PrintTarget {
         _matched=true;
         PrintResult _print = this.print("\"");
         PrintResult _apply = valuePrinter.apply(this, value);
-        PrintResult _plus = PrintResultExtension.operator_plus(_print, _apply);
+        PrintResult _plus = PrintResultExtension.operatorPlus(_print, _apply);
         PrintResult _print_1 = this.print("\"");
-        _switchResult = PrintResultExtension.operator_plus(_plus, _print_1);
+        _switchResult = PrintResultExtension.operatorPlus(_plus, _print_1);
       }
     }
     if (!_matched) {
       PrintResult _print = this.print("<");
       PrintResult _apply = valuePrinter.apply(this, value);
-      PrintResult _plus = PrintResultExtension.operator_plus(_print, _apply);
+      PrintResult _plus = PrintResultExtension.operatorPlus(_print, _apply);
       PrintResult _print_1 = this.print(">");
-      _switchResult = PrintResultExtension.operator_plus(_plus, _print_1);
+      _switchResult = PrintResultExtension.operatorPlus(_plus, _print_1);
     }
     return _switchResult;
   }

--- a/testutils/core/src/main/java/tools/vitruv/change/testutils/printing/PrintTarget.java
+++ b/testutils/core/src/main/java/tools/vitruv/change/testutils/printing/PrintTarget.java
@@ -50,17 +50,17 @@ public interface PrintTarget {
         _matched=true;
         PrintResult _print = this.print("\"");
         PrintResult _apply = valuePrinter.apply(this, value);
-        PrintResult _plus = PrintResultExtension.operatorPlus(_print, _apply);
+        PrintResult plus = PrintResultExtension.operatorPlus(_print, _apply);
         PrintResult _print_1 = this.print("\"");
-        _switchResult = PrintResultExtension.operatorPlus(_plus, _print_1);
+        _switchResult = PrintResultExtension.operatorPlus(plus, _print_1);
       }
     }
     if (!_matched) {
       PrintResult _print = this.print("<");
       PrintResult _apply = valuePrinter.apply(this, value);
-      PrintResult _plus = PrintResultExtension.operatorPlus(_print, _apply);
+      PrintResult plus = PrintResultExtension.operatorPlus(_print, _apply);
       PrintResult _print_1 = this.print(">");
-      _switchResult = PrintResultExtension.operatorPlus(_plus, _print_1);
+      _switchResult = PrintResultExtension.operatorPlus(plus, _print_1);
     }
     return _switchResult;
   }

--- a/testutils/core/src/test/java/tools/vitruv/change/testutils/printing/PrintResultExtensionTest.java
+++ b/testutils/core/src/test/java/tools/vitruv/change/testutils/printing/PrintResultExtensionTest.java
@@ -1,42 +1,42 @@
-        package tools.vitruv.change.testutils.printing;
+package tools.vitruv.change.testutils.printing;
 
-        import static org.junit.jupiter.api.Assertions.assertEquals;
-        import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-        import org.junit.jupiter.params.ParameterizedTest;
-        import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
-        /**
-         * Tests for {@link PrintResultExtension}.
-         */
-        public class PrintResultExtensionTest {
-            @ParameterizedTest
-            @CsvSource({
-                    "PRINTED, PRINTED, PRINTED",
-                    "PRINTED, PRINTED_NO_OUTPUT, PRINTED",
-                    "PRINTED_NO_OUTPUT, PRINTED, PRINTED",
-                    "PRINTED_NO_OUTPUT, PRINTED_NO_OUTPUT, PRINTED_NO_OUTPUT",
-                    "PRINTED_NO_OUTPUT, NOT_RESPONSIBLE, NOT_RESPONSIBLE",
-                    "NOT_RESPONSIBLE, PRINTED_NO_OUTPUT, NOT_RESPONSIBLE",
-                    "NOT_RESPONSIBLE, NOT_RESPONSIBLE, NOT_RESPONSIBLE"
-            })
-            void combinesPrintResults(
-                    final PrintResult previous,
-                    final PrintResult latest,
-                    final PrintResult expected) {
-                        assertEquals(expected, PrintResultExtension.operatorPlus(previous, latest));
-                    }
-
-            @ParameterizedTest
-            @CsvSource({
-                    "PRINTED, NOT_RESPONSIBLE",
-                    "NOT_RESPONSIBLE, PRINTED"
-            })
-            void rejectsInvalidPrintResultTransitions(
-                    final PrintResult previous,
-                    final PrintResult latest) {
-                assertThrows(
-                        IllegalStateException.class,
-                        () -> PrintResultExtension.operatorPlus(previous, latest));
+/**
+ * Tests for {@link PrintResultExtension}.
+ */
+public class PrintResultExtensionTest {
+    @ParameterizedTest
+    @CsvSource({
+            "PRINTED, PRINTED, PRINTED",
+            "PRINTED, PRINTED_NO_OUTPUT, PRINTED",
+            "PRINTED_NO_OUTPUT, PRINTED, PRINTED",
+            "PRINTED_NO_OUTPUT, PRINTED_NO_OUTPUT, PRINTED_NO_OUTPUT",
+            "PRINTED_NO_OUTPUT, NOT_RESPONSIBLE, NOT_RESPONSIBLE",
+            "NOT_RESPONSIBLE, PRINTED_NO_OUTPUT, NOT_RESPONSIBLE",
+            "NOT_RESPONSIBLE, NOT_RESPONSIBLE, NOT_RESPONSIBLE"
+    })
+    void combinesPrintResults(
+            final PrintResult previous,
+            final PrintResult latest,
+            final PrintResult expected) {
+                assertEquals(expected, PrintResultExtension.operatorPlus(previous, latest));
             }
-        }
+
+    @ParameterizedTest
+    @CsvSource({
+            "PRINTED, NOT_RESPONSIBLE",
+            "NOT_RESPONSIBLE, PRINTED"
+    })
+    void rejectsInvalidPrintResultTransitions(
+            final PrintResult previous,
+            final PrintResult latest) {
+        assertThrows(
+                IllegalStateException.class,
+                () -> PrintResultExtension.operatorPlus(previous, latest));
+    }
+}

--- a/testutils/core/src/test/java/tools/vitruv/change/testutils/printing/PrintResultExtensionTest.java
+++ b/testutils/core/src/test/java/tools/vitruv/change/testutils/printing/PrintResultExtensionTest.java
@@ -12,25 +12,25 @@ import org.junit.jupiter.params.provider.CsvSource;
 public class PrintResultExtensionTest {
     @ParameterizedTest
     @CsvSource({
-            "PRINTED, PRINTED, PRINTED",
-            "PRINTED, PRINTED_NO_OUTPUT, PRINTED",
-            "PRINTED_NO_OUTPUT, PRINTED, PRINTED",
-            "PRINTED_NO_OUTPUT, PRINTED_NO_OUTPUT, PRINTED_NO_OUTPUT",
-            "PRINTED_NO_OUTPUT, NOT_RESPONSIBLE, NOT_RESPONSIBLE",
-            "NOT_RESPONSIBLE, PRINTED_NO_OUTPUT, NOT_RESPONSIBLE",
-            "NOT_RESPONSIBLE, NOT_RESPONSIBLE, NOT_RESPONSIBLE"
+        "PRINTED, PRINTED, PRINTED",
+        "PRINTED, PRINTED_NO_OUTPUT, PRINTED",
+        "PRINTED_NO_OUTPUT, PRINTED, PRINTED",
+        "PRINTED_NO_OUTPUT, PRINTED_NO_OUTPUT, PRINTED_NO_OUTPUT",
+        "PRINTED_NO_OUTPUT, NOT_RESPONSIBLE, NOT_RESPONSIBLE",
+        "NOT_RESPONSIBLE, PRINTED_NO_OUTPUT, NOT_RESPONSIBLE",
+        "NOT_RESPONSIBLE, NOT_RESPONSIBLE, NOT_RESPONSIBLE"
     })
     void combinesPrintResults(
             final PrintResult previous,
             final PrintResult latest,
             final PrintResult expected) {
                 assertEquals(expected, PrintResultExtension.operatorPlus(previous, latest));
-            }
+    }
 
     @ParameterizedTest
     @CsvSource({
-            "PRINTED, NOT_RESPONSIBLE",
-            "NOT_RESPONSIBLE, PRINTED"
+        "PRINTED, NOT_RESPONSIBLE",
+        "NOT_RESPONSIBLE, PRINTED"
     })
     void rejectsInvalidPrintResultTransitions(
             final PrintResult previous,

--- a/testutils/core/src/test/java/tools/vitruv/change/testutils/printing/PrintResultExtensionTest.java
+++ b/testutils/core/src/test/java/tools/vitruv/change/testutils/printing/PrintResultExtensionTest.java
@@ -27,16 +27,16 @@ public class PrintResultExtensionTest {
                 assertEquals(expected, PrintResultExtension.operatorPlus(previous, latest));
     }
 
-    @ParameterizedTest
-    @CsvSource({
-        "PRINTED, NOT_RESPONSIBLE",
-        "NOT_RESPONSIBLE, PRINTED"
-    })
-    void rejectsInvalidPrintResultTransitions(
-            final PrintResult previous,
-            final PrintResult latest) {
-        assertThrows(
-                IllegalStateException.class,
-                () -> PrintResultExtension.operatorPlus(previous, latest));
-    }
+  @ParameterizedTest
+  @CsvSource({
+    "PRINTED, NOT_RESPONSIBLE",
+    "NOT_RESPONSIBLE, PRINTED"
+  })
+  void rejectsInvalidPrintResultTransitions(
+        final PrintResult previous,
+        final PrintResult latest) {
+    assertThrows(
+            IllegalStateException.class,
+            () -> PrintResultExtension.operatorPlus(previous, latest));
+  }
 }

--- a/testutils/core/src/test/java/tools/vitruv/change/testutils/printing/PrintResultExtensionTest.java
+++ b/testutils/core/src/test/java/tools/vitruv/change/testutils/printing/PrintResultExtensionTest.java
@@ -24,7 +24,7 @@ public class PrintResultExtensionTest {
         final PrintResult previous,
         final PrintResult latest,
         final PrintResult expected) {
-      assertEquals(expected, PrintResultExtension.operatorPlus(previous, latest));
+    assertEquals(expected, PrintResultExtension.operatorPlus(previous, latest));
   }
 
   @ParameterizedTest

--- a/testutils/core/src/test/java/tools/vitruv/change/testutils/printing/PrintResultExtensionTest.java
+++ b/testutils/core/src/test/java/tools/vitruv/change/testutils/printing/PrintResultExtensionTest.java
@@ -1,39 +1,42 @@
-package tools.vitruv.change.testutils.printing;
+    package tools.vitruv.change.testutils.printing;
 
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
+    import static org.junit.jupiter.api.Assertions.assertEquals;
+    import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+    import org.junit.jupiter.params.ParameterizedTest;
+    import org.junit.jupiter.params.provider.CsvSource;
 
-public class PrintResultExtensionTest {
-    @ParameterizedTest
-    @CsvSource({
-            "PRINTED, PRINTED, PRINTED",
-            "PRINTED, PRINTED_NO_OUTPUT, PRINTED",
-            "PRINTED_NO_OUTPUT, PRINTED, PRINTED",
-            "PRINTED_NO_OUTPUT, PRINTED_NO_OUTPUT, PRINTED_NO_OUTPUT",
-            "PRINTED_NO_OUTPUT, NOT_RESPONSIBLE, NOT_RESPONSIBLE",
-            "NOT_RESPONSIBLE, PRINTED_NO_OUTPUT, NOT_RESPONSIBLE",
-            "NOT_RESPONSIBLE, NOT_RESPONSIBLE, NOT_RESPONSIBLE"
-    })
-    void combinesPrintResults(
-            final PrintResult previous,
-            final PrintResult latest,
-            final PrintResult expected) {
-        assertEquals(expected, PrintResultExtension.operator_plus(previous, latest));
+    /**
+     * Tests for {@link PrintResultExtension}.
+     */
+    public class PrintResultExtensionTest {
+        @ParameterizedTest
+        @CsvSource({
+                "PRINTED, PRINTED, PRINTED",
+                "PRINTED, PRINTED_NO_OUTPUT, PRINTED",
+                "PRINTED_NO_OUTPUT, PRINTED, PRINTED",
+                "PRINTED_NO_OUTPUT, PRINTED_NO_OUTPUT, PRINTED_NO_OUTPUT",
+                "PRINTED_NO_OUTPUT, NOT_RESPONSIBLE, NOT_RESPONSIBLE",
+                "NOT_RESPONSIBLE, PRINTED_NO_OUTPUT, NOT_RESPONSIBLE",
+                "NOT_RESPONSIBLE, NOT_RESPONSIBLE, NOT_RESPONSIBLE"
+        })
+        void combinesPrintResults(
+                final PrintResult previous,
+                final PrintResult latest,
+                final PrintResult expected) {
+                    assertEquals(expected, PrintResultExtension.operatorPlus(previous, latest));
+                }
+
+        @ParameterizedTest
+        @CsvSource({
+                "PRINTED, NOT_RESPONSIBLE",
+                "NOT_RESPONSIBLE, PRINTED"
+        })
+        void rejectsInvalidPrintResultTransitions(
+                final PrintResult previous,
+                final PrintResult latest) {
+            assertThrows(
+                    IllegalStateException.class,
+                    () -> PrintResultExtension.operatorPlus(previous, latest));
+        }
     }
-
-    @ParameterizedTest
-    @CsvSource({
-            "PRINTED, NOT_RESPONSIBLE",
-            "NOT_RESPONSIBLE, PRINTED"
-    })
-    void rejectsInvalidPrintResultTransitions(
-            final PrintResult previous,
-            final PrintResult latest) {
-        assertThrows(
-                IllegalStateException.class,
-                () -> PrintResultExtension.operator_plus(previous, latest));
-    }
-}

--- a/testutils/core/src/test/java/tools/vitruv/change/testutils/printing/PrintResultExtensionTest.java
+++ b/testutils/core/src/test/java/tools/vitruv/change/testutils/printing/PrintResultExtensionTest.java
@@ -10,22 +10,22 @@ import org.junit.jupiter.params.provider.CsvSource;
  * Tests for {@link PrintResultExtension}.
  */
 public class PrintResultExtensionTest {
-    @ParameterizedTest
-    @CsvSource({
-        "PRINTED, PRINTED, PRINTED",
-        "PRINTED, PRINTED_NO_OUTPUT, PRINTED",
-        "PRINTED_NO_OUTPUT, PRINTED, PRINTED",
-        "PRINTED_NO_OUTPUT, PRINTED_NO_OUTPUT, PRINTED_NO_OUTPUT",
-        "PRINTED_NO_OUTPUT, NOT_RESPONSIBLE, NOT_RESPONSIBLE",
-        "NOT_RESPONSIBLE, PRINTED_NO_OUTPUT, NOT_RESPONSIBLE",
-        "NOT_RESPONSIBLE, NOT_RESPONSIBLE, NOT_RESPONSIBLE"
-    })
-    void combinesPrintResults(
-            final PrintResult previous,
-            final PrintResult latest,
-            final PrintResult expected) {
-                assertEquals(expected, PrintResultExtension.operatorPlus(previous, latest));
-    }
+  @ParameterizedTest
+  @CsvSource({
+    "PRINTED, PRINTED, PRINTED",
+    "PRINTED, PRINTED_NO_OUTPUT, PRINTED",
+    "PRINTED_NO_OUTPUT, PRINTED, PRINTED",
+    "PRINTED_NO_OUTPUT, PRINTED_NO_OUTPUT, PRINTED_NO_OUTPUT",
+    "PRINTED_NO_OUTPUT, NOT_RESPONSIBLE, NOT_RESPONSIBLE",
+    "NOT_RESPONSIBLE, PRINTED_NO_OUTPUT, NOT_RESPONSIBLE",
+    "NOT_RESPONSIBLE, NOT_RESPONSIBLE, NOT_RESPONSIBLE"
+  })
+  void combinesPrintResults(
+        final PrintResult previous,
+        final PrintResult latest,
+        final PrintResult expected) {
+            assertEquals(expected, PrintResultExtension.operatorPlus(previous, latest));
+  }
 
   @ParameterizedTest
   @CsvSource({

--- a/testutils/core/src/test/java/tools/vitruv/change/testutils/printing/PrintResultExtensionTest.java
+++ b/testutils/core/src/test/java/tools/vitruv/change/testutils/printing/PrintResultExtensionTest.java
@@ -24,7 +24,7 @@ public class PrintResultExtensionTest {
         final PrintResult previous,
         final PrintResult latest,
         final PrintResult expected) {
-            assertEquals(expected, PrintResultExtension.operatorPlus(previous, latest));
+      assertEquals(expected, PrintResultExtension.operatorPlus(previous, latest));
   }
 
   @ParameterizedTest

--- a/testutils/core/src/test/java/tools/vitruv/change/testutils/printing/PrintResultExtensionTest.java
+++ b/testutils/core/src/test/java/tools/vitruv/change/testutils/printing/PrintResultExtensionTest.java
@@ -1,42 +1,42 @@
-    package tools.vitruv.change.testutils.printing;
+        package tools.vitruv.change.testutils.printing;
 
-    import static org.junit.jupiter.api.Assertions.assertEquals;
-    import static org.junit.jupiter.api.Assertions.assertThrows;
+        import static org.junit.jupiter.api.Assertions.assertEquals;
+        import static org.junit.jupiter.api.Assertions.assertThrows;
 
-    import org.junit.jupiter.params.ParameterizedTest;
-    import org.junit.jupiter.params.provider.CsvSource;
+        import org.junit.jupiter.params.ParameterizedTest;
+        import org.junit.jupiter.params.provider.CsvSource;
 
-    /**
-     * Tests for {@link PrintResultExtension}.
-     */
-    public class PrintResultExtensionTest {
-        @ParameterizedTest
-        @CsvSource({
-                "PRINTED, PRINTED, PRINTED",
-                "PRINTED, PRINTED_NO_OUTPUT, PRINTED",
-                "PRINTED_NO_OUTPUT, PRINTED, PRINTED",
-                "PRINTED_NO_OUTPUT, PRINTED_NO_OUTPUT, PRINTED_NO_OUTPUT",
-                "PRINTED_NO_OUTPUT, NOT_RESPONSIBLE, NOT_RESPONSIBLE",
-                "NOT_RESPONSIBLE, PRINTED_NO_OUTPUT, NOT_RESPONSIBLE",
-                "NOT_RESPONSIBLE, NOT_RESPONSIBLE, NOT_RESPONSIBLE"
-        })
-        void combinesPrintResults(
-                final PrintResult previous,
-                final PrintResult latest,
-                final PrintResult expected) {
-                    assertEquals(expected, PrintResultExtension.operatorPlus(previous, latest));
-                }
+        /**
+         * Tests for {@link PrintResultExtension}.
+         */
+        public class PrintResultExtensionTest {
+            @ParameterizedTest
+            @CsvSource({
+                    "PRINTED, PRINTED, PRINTED",
+                    "PRINTED, PRINTED_NO_OUTPUT, PRINTED",
+                    "PRINTED_NO_OUTPUT, PRINTED, PRINTED",
+                    "PRINTED_NO_OUTPUT, PRINTED_NO_OUTPUT, PRINTED_NO_OUTPUT",
+                    "PRINTED_NO_OUTPUT, NOT_RESPONSIBLE, NOT_RESPONSIBLE",
+                    "NOT_RESPONSIBLE, PRINTED_NO_OUTPUT, NOT_RESPONSIBLE",
+                    "NOT_RESPONSIBLE, NOT_RESPONSIBLE, NOT_RESPONSIBLE"
+            })
+            void combinesPrintResults(
+                    final PrintResult previous,
+                    final PrintResult latest,
+                    final PrintResult expected) {
+                        assertEquals(expected, PrintResultExtension.operatorPlus(previous, latest));
+                    }
 
-        @ParameterizedTest
-        @CsvSource({
-                "PRINTED, NOT_RESPONSIBLE",
-                "NOT_RESPONSIBLE, PRINTED"
-        })
-        void rejectsInvalidPrintResultTransitions(
-                final PrintResult previous,
-                final PrintResult latest) {
-            assertThrows(
-                    IllegalStateException.class,
-                    () -> PrintResultExtension.operatorPlus(previous, latest));
+            @ParameterizedTest
+            @CsvSource({
+                    "PRINTED, NOT_RESPONSIBLE",
+                    "NOT_RESPONSIBLE, PRINTED"
+            })
+            void rejectsInvalidPrintResultTransitions(
+                    final PrintResult previous,
+                    final PrintResult latest) {
+                assertThrows(
+                        IllegalStateException.class,
+                        () -> PrintResultExtension.operatorPlus(previous, latest));
+            }
         }
-    }

--- a/testutils/core/src/test/java/tools/vitruv/change/testutils/printing/PrintResultExtensionTest.java
+++ b/testutils/core/src/test/java/tools/vitruv/change/testutils/printing/PrintResultExtensionTest.java
@@ -1,0 +1,39 @@
+package tools.vitruv.change.testutils.printing;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class PrintResultExtensionTest {
+    @ParameterizedTest
+    @CsvSource({
+            "PRINTED, PRINTED, PRINTED",
+            "PRINTED, PRINTED_NO_OUTPUT, PRINTED",
+            "PRINTED_NO_OUTPUT, PRINTED, PRINTED",
+            "PRINTED_NO_OUTPUT, PRINTED_NO_OUTPUT, PRINTED_NO_OUTPUT",
+            "PRINTED_NO_OUTPUT, NOT_RESPONSIBLE, NOT_RESPONSIBLE",
+            "NOT_RESPONSIBLE, PRINTED_NO_OUTPUT, NOT_RESPONSIBLE",
+            "NOT_RESPONSIBLE, NOT_RESPONSIBLE, NOT_RESPONSIBLE"
+    })
+    void combinesPrintResults(
+            final PrintResult previous,
+            final PrintResult latest,
+            final PrintResult expected) {
+        assertEquals(expected, PrintResultExtension.operator_plus(previous, latest));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "PRINTED, NOT_RESPONSIBLE",
+            "NOT_RESPONSIBLE, PRINTED"
+    })
+    void rejectsInvalidPrintResultTransitions(
+            final PrintResult previous,
+            final PrintResult latest) {
+        assertThrows(
+                IllegalStateException.class,
+                () -> PrintResultExtension.operator_plus(previous, latest));
+    }
+}


### PR DESCRIPTION
## Summary

Refactored the `PrintResult` combination logic to reduce cognitive complexity and improve maintainability.

## Changes

- Replaced nested switch logic with simpler conditional flow
- Extracted invalid transition handling into helper methods
- Removed unnecessary checks and unused imports
- Added exhaustive tests for valid, invalid, and null input cases